### PR TITLE
Add an optional Postgres game-history database (Supabase)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Copy this file to .env and fill in real values -- .env itself is
+# gitignored, so your actual connection string never gets committed.
+
+# Optional. Only needed for the game-history database feature (see
+# highsociety/code/common/db/game_history.py and README.md's "Game history
+# database" section). Leave unset/commented out and the app runs exactly as
+# before, with no database at all.
+# Get this from a free Supabase project: Project Settings -> Database ->
+# Connection string -> URI (the "Session pooler" one).
+# DATABASE_URL=postgresql://postgres.xxxxxxxx:yourpassword@aws-0-xxxxx.pooler.supabase.com:5432/postgres

--- a/README.md
+++ b/README.md
@@ -109,9 +109,11 @@ providers):
 1. Create a free Supabase account and a new project.
 2. In the project dashboard, go to **Project Settings → Database → Connection string** and copy
    the URI (the "Session pooler" or direct connection string both work).
-3. Set it as an environment variable before starting the server:
-   `export DATABASE_URL="postgresql://..."` (locally), or as a secret/environment variable in
-   whatever hosting service ends up running this (Render, Railway, etc.).
+3. Copy `.env.example` to `.env` and paste it in as `DATABASE_URL=postgresql://...` — `.env` is
+   gitignored, so it never gets committed. `web_server.py` loads it automatically at startup (via
+   `python-dotenv`), so no manual `export` is needed locally. A real hosting service (Render,
+   Railway, etc.) has no `.env` file to find, so there you'd set `DATABASE_URL` as a secret/
+   environment variable in its own dashboard instead.
 4. Start the app as usual. The three tables (`players`, `games`, `player_games`) are created
    automatically on first startup if they don't already exist — no manual migration step.
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,35 @@ Game rules (starting cash, painting values, disgrace card types, player limits, 
 limit, etc.) live in `highsociety/HSConfig.json` — see `highsociety/code/HSConfig.md` for a
 field-by-field description.
 
+## Game history database (optional)
+
+`web_server.py` can persist every finished game (room, seats, bot mix, and each participant's
+final points/money/win-or-loss — see `highsociety/code/common/db/game_history.py`'s docstring for
+the exact schema) to a Postgres database. This is entirely optional and off by default: unless the
+`DATABASE_URL` environment variable is set, nothing here is ever touched (no import, no connection
+attempt), so the app runs exactly as before without a database configured.
+
+To turn it on, using [Supabase](https://supabase.com)'s free tier (chosen because it's Postgres —
+a natural fit for "map players to their past games" — and its optional Google-sign-in auth product
+means the same free project can cover a later real-accounts feature too, without switching
+providers):
+
+1. Create a free Supabase account and a new project.
+2. In the project dashboard, go to **Project Settings → Database → Connection string** and copy
+   the URI (the "Session pooler" or direct connection string both work).
+3. Set it as an environment variable before starting the server:
+   `export DATABASE_URL="postgresql://..."` (locally), or as a secret/environment variable in
+   whatever hosting service ends up running this (Render, Railway, etc.).
+4. Start the app as usual. The three tables (`players`, `games`, `player_games`) are created
+   automatically on first startup if they don't already exist — no manual migration step.
+
+A player's identity is keyed by their `username` today (there's no login system yet), but the
+schema already has nullable `google_id`/`email` columns on `players` so a future Google Sign-In
+can attach a real identity to an existing player's row without any schema change or data migration.
+A database write happening slowly or failing outright never affects gameplay — it happens
+fire-and-forget on a background thread after a game has already fully finished (see
+`record_finished_game_async`).
+
 ## Status
 
 CLI, networked, and browser play are all functional, covered by the test suite under `tests/`

--- a/highsociety/code/common/db/game_history.py
+++ b/highsociety/code/common/db/game_history.py
@@ -1,0 +1,199 @@
+"""
+Persists finished games to a Postgres database (see README's "Game history
+database" section) so a player could eventually be shown their own past
+games. Entirely optional: unless the DATABASE_URL environment variable is
+set, every public function here is a no-op, so this can never affect an
+existing local/dev/test setup that hasn't configured a database. A game
+whose write fails or is slow also never blocks the actual game-over message
+reaching players — see record_finished_game_async.
+
+Schema (3 tables, see _SCHEMA_STATEMENTS for the exact DDL):
+  players       One row per distinct human username ever seen. `username`
+                is the identity key today, since there's no login system
+                yet — the nullable google_id/email columns exist so a future
+                Google Sign-In can attach a *real* identity to an existing
+                players.id later without changing any foreign key that
+                already points at it.
+  games         One row per finished game, including each rematch (a
+                rematch is just another call to record_finished_game).
+  player_games  The "key that maps players to their past games": one row
+                per (game, participant). Bots have no persistent identity to
+                attach a row to, so they're recorded by name only
+                (player_id NULL, bot_name set) rather than being forced into
+                the players table.
+"""
+import datetime
+import json
+import os
+import threading
+
+from highsociety.code.common.logger_module.logger.logging_manager import LoggingManager
+
+_DATABASE_URL_ENV = "DATABASE_URL"
+
+_SCHEMA_STATEMENTS = [
+    """
+    CREATE TABLE IF NOT EXISTS players (
+        id SERIAL PRIMARY KEY,
+        username TEXT NOT NULL UNIQUE,
+        display_name TEXT NOT NULL,
+        google_id TEXT UNIQUE,
+        email TEXT UNIQUE,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+        last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS games (
+        id SERIAL PRIMARY KEY,
+        room_code TEXT NOT NULL,
+        seats INTEGER NOT NULL,
+        bot_mix JSONB NOT NULL DEFAULT '[]',
+        started_at TIMESTAMPTZ NOT NULL,
+        finished_at TIMESTAMPTZ NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS player_games (
+        id SERIAL PRIMARY KEY,
+        game_id INTEGER NOT NULL REFERENCES games(id) ON DELETE CASCADE,
+        player_id INTEGER REFERENCES players(id) ON DELETE CASCADE,
+        bot_name TEXT,
+        points INTEGER NOT NULL,
+        money_left INTEGER NOT NULL,
+        is_winner BOOLEAN NOT NULL DEFAULT FALSE,
+        eliminated BOOLEAN NOT NULL DEFAULT FALSE,
+        CONSTRAINT player_xor_bot CHECK ((player_id IS NULL) <> (bot_name IS NULL))
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_player_games_player_id ON player_games (player_id)",
+    "CREATE INDEX IF NOT EXISTS idx_player_games_game_id ON player_games (game_id)",
+]
+
+_schema_ready = False
+_schema_lock = threading.Lock()
+
+
+def is_configured() -> bool:
+    return bool(os.environ.get(_DATABASE_URL_ENV))
+
+
+def _connect():
+    # Imported lazily so merely importing this module (which web_server.py
+    # does unconditionally) never fails for a dev/test setup that hasn't
+    # installed psycopg2 — only actually needed once DATABASE_URL is set.
+    import psycopg2
+    return psycopg2.connect(os.environ[_DATABASE_URL_ENV])
+
+
+def ensure_schema() -> None:
+    """
+    Idempotent (CREATE TABLE/INDEX IF NOT EXISTS) — safe to call on every
+    process start, which matters because it needs to run identically whether
+    the app is started directly (`python3 web_server.py`) or imported fresh
+    by each of gunicorn's own worker processes in production.
+    """
+    global _schema_ready
+    if not is_configured() or _schema_ready:
+        return
+    with _schema_lock:
+        if _schema_ready:
+            return
+        conn = None
+        try:
+            conn = _connect()
+            with conn, conn.cursor() as cur:
+                for statement in _SCHEMA_STATEMENTS:
+                    cur.execute(statement)
+            _schema_ready = True
+        except Exception as e:  # noqa: BLE001 — a DB hiccup at startup must never crash the app
+            LoggingManager.warning(f"game_history.ensure_schema failed, game history disabled: {e}")
+        finally:
+            if conn is not None:
+                conn.close()
+
+
+def _upsert_player(cur, username: str, display_name: str) -> int:
+    cur.execute(
+        """
+        INSERT INTO players (username, display_name)
+        VALUES (%s, %s)
+        ON CONFLICT (username) DO UPDATE SET display_name = EXCLUDED.display_name, last_seen_at = now()
+        RETURNING id
+        """,
+        (username, display_name),
+    )
+    return cur.fetchone()[0]
+
+
+def record_finished_game(*, room_code: str, seats: int, bot_mix: list,
+                          started_at: datetime.datetime, finished_at: datetime.datetime,
+                          participants: list) -> None:
+    """
+    `participants`: one dict per seat, already reduced to exactly what this
+    module needs — see web_server.py's call site for how it's built from
+    PlayGame.final_standings/GameRoom.players. Keeping that translation in
+    the caller (rather than importing NetworkPlayer/PlayGame here) is what
+    lets this stay a plain, independently-testable persistence layer with no
+    dependency on the game engine's own classes.
+
+    Each participant: {"is_bot": bool, "username": str | None, "name": str,
+                        "points": int, "money_left": int, "is_winner": bool,
+                        "eliminated": bool}
+    Exactly one of (is_bot False + username set) or (is_bot True + username
+    None) holds per participant — see the player_xor_bot constraint.
+    """
+    if not is_configured():
+        return
+    ensure_schema()
+    if not _schema_ready:
+        return  # schema setup already failed and logged a warning above
+    conn = None
+    try:
+        conn = _connect()
+        with conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO games (room_code, seats, bot_mix, started_at, finished_at)
+                VALUES (%s, %s, %s, %s, %s)
+                RETURNING id
+                """,
+                (room_code, seats, json.dumps(bot_mix), started_at, finished_at),
+            )
+            game_id = cur.fetchone()[0]
+            for p in participants:
+                player_id = None
+                bot_name = None
+                if p["is_bot"]:
+                    bot_name = p["name"]
+                else:
+                    player_id = _upsert_player(cur, p["username"], p["name"])
+                cur.execute(
+                    """
+                    INSERT INTO player_games
+                        (game_id, player_id, bot_name, points, money_left, is_winner, eliminated)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (game_id, player_id, bot_name, p["points"], p["money_left"],
+                     p["is_winner"], p["eliminated"]),
+                )
+    except Exception as e:  # noqa: BLE001 — see record_finished_game_async's docstring
+        LoggingManager.warning(f"game_history.record_finished_game failed: {e}")
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def record_finished_game_async(**kwargs) -> None:
+    """
+    Fire-and-forget wrapper — the only entry point web_server.py's actual
+    game-end path calls, since it must never wait on (or fail because of) a
+    slow/unreachable database. A finished game already has everything it'll
+    ever have by this point, so nothing time-sensitive is being raced here:
+    worst case, this game's row shows up a moment late or not at all
+    (logged), while every player-facing message still goes out on schedule.
+    """
+    if not is_configured():
+        return
+    threading.Thread(target=record_finished_game, kwargs=kwargs, daemon=True,
+                      name="GameHistoryWrite").start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,9 @@ flask-sock
 # practice — see the hosting platform's own gunicorn error if this ever
 # regresses).
 gunicorn
+# Optional: only imported/needed once DATABASE_URL is set (see
+# highsociety/code/common/db/game_history.py) — the app runs fine without a
+# database configured at all, this just needs to be installed for when one
+# is. "-binary" ships a prebuilt wheel so this doesn't need Postgres's own
+# dev headers/build toolchain on whatever machine/host installs it.
+psycopg2-binary

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,9 @@ gunicorn
 # is. "-binary" ships a prebuilt wheel so this doesn't need Postgres's own
 # dev headers/build toolchain on whatever machine/host installs it.
 psycopg2-binary
+# Loads a local .env file (e.g. DATABASE_URL) into the environment at
+# startup (see web_server.py's load_dotenv() call) — a convenience for local
+# dev so you don't have to `export` secrets by hand every terminal session.
+# A real host (Render/Railway/etc.) sets env vars its own way and simply has
+# no .env file to find, so this is a no-op there.
+python-dotenv

--- a/tests/common/test_game_history.py
+++ b/tests/common/test_game_history.py
@@ -1,0 +1,144 @@
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from highsociety.code.common.db import game_history
+
+
+@pytest.fixture(autouse=True)
+def reset_schema_cache():
+    """_schema_ready is a module-level cache (see ensure_schema's docstring
+    for why) — reset it around every test so one test's mocked "schema is
+    ready" state can't leak into the next."""
+    game_history._schema_ready = False
+    yield
+    game_history._schema_ready = False
+
+
+@pytest.fixture
+def no_database_url(monkeypatch):
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+
+@pytest.fixture
+def database_url(monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@localhost/testdb")
+
+
+def test_is_configured_reflects_the_env_var(no_database_url, monkeypatch):
+    assert game_history.is_configured() is False
+    monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+    assert game_history.is_configured() is True
+
+
+def test_ensure_schema_is_a_silent_no_op_without_a_database(no_database_url):
+    game_history.ensure_schema()
+    assert game_history._schema_ready is False
+
+
+def test_record_finished_game_is_a_silent_no_op_without_a_database(no_database_url):
+    # Must not raise even though every field below is nonsense -- the whole
+    # point is that this never gets far enough to touch any of it.
+    game_history.record_finished_game(
+        room_code="ABCDE", seats=2, bot_mix=["greedy"],
+        started_at=datetime.datetime.now(datetime.timezone.utc),
+        finished_at=datetime.datetime.now(datetime.timezone.utc),
+        participants=[{"is_bot": True, "username": None, "name": "Marble",
+                       "points": 5, "money_left": 10, "is_winner": True, "eliminated": False}],
+    )
+
+
+def test_record_finished_game_async_spawns_nothing_without_a_database(no_database_url):
+    with patch("threading.Thread") as mock_thread:
+        game_history.record_finished_game_async(room_code="ABCDE")
+        mock_thread.assert_not_called()
+
+
+def _fake_connection():
+    """A MagicMock standing in for a psycopg2 connection whose cursor's
+    fetchone() always returns a fresh, incrementing id -- enough to exercise
+    ensure_schema/record_finished_game's real SQL-issuing logic without a
+    real Postgres server."""
+    conn = MagicMock()
+    cursor = MagicMock()
+    ids = iter(range(1, 1000))
+    cursor.fetchone.side_effect = lambda: (next(ids),)
+    conn.cursor.return_value.__enter__.return_value = cursor
+    conn.__enter__.return_value = conn
+    return conn, cursor
+
+
+def test_ensure_schema_runs_every_ddl_statement_once(database_url):
+    conn, cursor = _fake_connection()
+    with patch.object(game_history, "_connect", return_value=conn):
+        game_history.ensure_schema()
+    assert cursor.execute.call_count == len(game_history._SCHEMA_STATEMENTS)
+    assert game_history._schema_ready is True
+    conn.close.assert_called_once()
+
+
+def test_ensure_schema_failure_is_caught_and_leaves_schema_not_ready(database_url):
+    with patch.object(game_history, "_connect", side_effect=RuntimeError("unreachable")):
+        game_history.ensure_schema()  # must not raise
+    assert game_history._schema_ready is False
+
+
+def test_record_finished_game_writes_one_row_per_human_and_bot_participant(database_url):
+    game_history._schema_ready = True  # skip ensure_schema's own DDL round-trip for this test
+    conn, cursor = _fake_connection()
+    participants = [
+        {"is_bot": False, "username": "alice", "name": "Alice",
+         "points": 12, "money_left": 3, "is_winner": True, "eliminated": False},
+        {"is_bot": True, "username": None, "name": "Marble",
+         "points": 5, "money_left": 0, "is_winner": False, "eliminated": True},
+    ]
+    with patch.object(game_history, "_connect", return_value=conn):
+        game_history.record_finished_game(
+            room_code="ABCDE", seats=2, bot_mix=["greedy"],
+            started_at=datetime.datetime.now(datetime.timezone.utc),
+            finished_at=datetime.datetime.now(datetime.timezone.utc),
+            participants=participants,
+        )
+
+    queries = [call.args[0] for call in cursor.execute.call_args_list]
+    assert sum("INSERT INTO games" in q for q in queries) == 1
+    assert sum("INSERT INTO players" in q for q in queries) == 1  # only alice, not the bot
+    assert sum("INSERT INTO player_games" in q for q in queries) == 2  # one per participant
+
+    # The bot's row must carry a bot_name with no player_id (see the
+    # player_xor_bot CHECK constraint in the schema).
+    player_games_calls = [call for call in cursor.execute.call_args_list
+                           if "INSERT INTO player_games" in call.args[0]]
+    bot_row_params = player_games_calls[1].args[1]
+    game_id, player_id, bot_name = bot_row_params[0], bot_row_params[1], bot_row_params[2]
+    assert player_id is None
+    assert bot_name == "Marble"
+    conn.close.assert_called_once()
+
+
+def test_record_finished_game_failure_is_caught_not_raised(database_url):
+    game_history._schema_ready = True
+    with patch.object(game_history, "_connect", side_effect=RuntimeError("unreachable")):
+        game_history.record_finished_game(
+            room_code="ABCDE", seats=2, bot_mix=[],
+            started_at=datetime.datetime.now(datetime.timezone.utc),
+            finished_at=datetime.datetime.now(datetime.timezone.utc),
+            participants=[],
+        )  # must not raise
+
+
+def test_record_finished_game_async_runs_in_a_background_thread(database_url):
+    game_history._schema_ready = True
+    conn, cursor = _fake_connection()
+    with patch.object(game_history, "_connect", return_value=conn):
+        game_history.record_finished_game_async(
+            room_code="ABCDE", seats=2, bot_mix=[],
+            started_at=datetime.datetime.now(datetime.timezone.utc),
+            finished_at=datetime.datetime.now(datetime.timezone.utc),
+            participants=[],
+        )
+        # Give the background thread a moment to actually run.
+        import time
+        time.sleep(0.2)
+    assert any("INSERT INTO games" in call.args[0] for call in cursor.execute.call_args_list)

--- a/tests/network/test_web_server.py
+++ b/tests/network/test_web_server.py
@@ -2,9 +2,11 @@ import itertools
 import json
 import threading
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
+from highsociety.code.common.db import game_history
 from highsociety.code.gamecore.card_manager.money_card_manager import MoneyCardManager
 
 # CLI/socket play has zero third-party dependencies (see README.md); only the
@@ -339,6 +341,53 @@ def test_full_game_over_websockets_against_a_bot(running_web_server):
     assert status["state"] == "finished"
     assert status["winners"] is not None
     assert len(status["final_standings"]) == 2
+
+    player.close()
+
+
+def test_finished_game_is_recorded_when_a_database_is_configured(running_web_server, monkeypatch):
+    """Exercises the real _record_game_history translation (web_server.py)
+    against a real finished game, with only the database connection itself
+    faked out — see tests/common/test_game_history.py for game_history's own
+    unit tests, which this deliberately doesn't re-duplicate."""
+    port = running_web_server
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@localhost/testdb")
+    game_history._schema_ready = True  # skip the real DDL round-trip for this test
+    conn = MagicMock()
+    cursor = MagicMock()
+    ids = iter(range(1, 1000))
+    cursor.fetchone.side_effect = lambda: (next(ids),)
+    conn.cursor.return_value.__enter__.return_value = cursor
+    conn.__enter__.return_value = conn
+    monkeypatch.setattr(game_history, "_connect", lambda: conn)
+    # Run synchronously so the test doesn't have to race a background thread
+    # for a database write that, in production, is deliberately fire-and-forget.
+    monkeypatch.setattr(game_history, "record_finished_game_async",
+                         lambda **kwargs: game_history.record_finished_game(**kwargs))
+
+    resp = web_server.app.test_client().post(
+        "/api/create_game", json={"seats": 2, "bot_mix": ["pass"], "seed": 42, "bot_think_time": 0}
+    )
+    room_code = resp.get_json()["room_code"]
+    player = ScriptedWSClient(_ws_url(port, f"/ws?room={room_code}"), "alice")
+    player.handshake()
+    player.start()
+
+    room = web_server._rooms[room_code]
+    deadline = time.time() + 30
+    while time.time() < deadline and room.state != "finished":
+        threading.Event().wait(0.2)
+    assert room.state == "finished"
+
+    queries = [call.args[0] for call in cursor.execute.call_args_list]
+    assert any("INSERT INTO games" in q for q in queries)
+    player_games_calls = [c for c in cursor.execute.call_args_list if "INSERT INTO player_games" in c.args[0]]
+    assert len(player_games_calls) == 2  # alice + the pass bot
+
+    # One row per participant: the bot has no player_id (params[1]), the
+    # human does -- see the player_xor_bot schema constraint.
+    player_ids = sorted((c.args[1][1] is None) for c in player_games_calls)
+    assert player_ids == [False, True]
 
     player.close()
 

--- a/web_server.py
+++ b/web_server.py
@@ -27,6 +27,7 @@ import time
 import uuid
 from typing import Optional
 
+from dotenv import load_dotenv
 from flask import Flask, jsonify, render_template, request
 from flask_sock import Sock
 
@@ -57,6 +58,12 @@ app = Flask(__name__, template_folder=os.path.join(WEB_DIR, "templates"),
 # custom PING-message convention or a heartbeat-monitor thread here.
 app.config['SOCK_SERVER_OPTIONS'] = {"ping_interval": 20}
 sock = Sock(app)
+
+# Pulls DATABASE_URL (and anything else in a local .env file) into the
+# environment before ensure_schema() below reads it — a no-op if no .env
+# file exists, which is exactly the case on a real host that sets env vars
+# its own way (Render/Railway/etc.), so this only ever matters for local dev.
+load_dotenv()
 
 # No-op unless DATABASE_URL is set (see game_history's module docstring) —
 # safe to call unconditionally on every process start, including once per

--- a/web_server.py
+++ b/web_server.py
@@ -16,6 +16,7 @@ existing Transport interface. See README.md's "Architecture: adding a new
 frontend" section, which called this out as the intended extension point.
 """
 import argparse
+import datetime
 import json
 import os
 import random
@@ -30,6 +31,7 @@ from flask import Flask, jsonify, render_template, request
 from flask_sock import Sock
 
 from highsociety.code.ai import BOT_TYPES, create_bot_players
+from highsociety.code.common.db import game_history
 from highsociety.code.common.logger_module.logger.logging_manager import LoggingManager, LogType
 from highsociety.code.common.utils.network_utility import get_local_ip
 from highsociety.code.common.utils.utility import (
@@ -55,6 +57,11 @@ app = Flask(__name__, template_folder=os.path.join(WEB_DIR, "templates"),
 # custom PING-message convention or a heartbeat-monitor thread here.
 app.config['SOCK_SERVER_OPTIONS'] = {"ping_interval": 20}
 sock = Sock(app)
+
+# No-op unless DATABASE_URL is set (see game_history's module docstring) —
+# safe to call unconditionally on every process start, including once per
+# gunicorn worker in production.
+game_history.ensure_schema()
 
 
 class GameRoom:
@@ -133,6 +140,7 @@ class GameRoom:
 
     def run_game(self) -> None:
         def _run():
+            started_at = datetime.datetime.now(datetime.timezone.utc)
             game = PlayGame(players=self.players, spectators=self.spectators,
                              mode='network', game_id=self.game_id, seed=self.seed,
                              turn_duration=self.turn_time_limit)
@@ -148,6 +156,7 @@ class GameRoom:
             game.play_game()
             self.state = "finished"
             self.touch()  # start the reaper's finished-room retention window from now
+            _record_game_history(self, game, started_at)
             # Unlike before, human players' connections are deliberately left
             # open here instead of closed — a rematch (see
             # _start_rematch_request/_maybe_start_rematch) reuses the same
@@ -165,6 +174,41 @@ class GameRoom:
                 s.close()
 
         threading.Thread(target=_run, daemon=True, name=f"Game-{self.game_id}").start()
+
+
+def _record_game_history(room: "GameRoom", game: PlayGame, started_at: datetime.datetime) -> None:
+    """Translates this finished game into the plain-dict shape game_history
+    expects (see its own docstring for the schema/rationale), then hands off
+    to its fire-and-forget writer — cheap to call even when no database is
+    configured, since is_configured() short-circuits before touching a
+    network connection."""
+    if not game_history.is_configured():
+        return
+    winner_usernames = {w.username for w in (game.winners or [])}
+    players_by_username = {p.username: p for p in room.players}
+    participants = []
+    for standing in game.final_standings:
+        player = players_by_username.get(standing["username"])
+        if player is None:
+            continue
+        is_bot = not isinstance(player, NetworkPlayer)
+        participants.append({
+            "is_bot": is_bot,
+            "username": None if is_bot else player.username,
+            "name": player.name,
+            "points": standing["points"],
+            "money_left": standing["money_left"],
+            "is_winner": standing["username"] in winner_usernames,
+            "eliminated": standing["eliminated"],
+        })
+    game_history.record_finished_game_async(
+        room_code=room.room_code,
+        seats=room.seats,
+        bot_mix=room.bot_mix,
+        started_at=started_at,
+        finished_at=datetime.datetime.now(datetime.timezone.utc),
+        participants=participants,
+    )
 
 
 # Excludes 0/O and 1/I — a room code is meant to be read aloud or typed by a


### PR DESCRIPTION
## Summary
- New `highsociety/code/common/db/game_history.py`: fully opt-in persistence layer. Unless `DATABASE_URL` is set, every function is a no-op (no import, no connection attempt) — an unconfigured deployment behaves exactly as before.
- Schema: `players` (keyed by `username` today; nullable `google_id`/`email` columns reserved for a future Google Sign-In), `games` (one row per finished game, including each rematch), and `player_games` (one row per participant, covering both real players and bots).
- `web_server.py`: `ensure_schema()` runs once at process start; `_record_game_history()` translates a finished game's standings into the plain dicts `game_history` expects, then hands off to a fire-and-forget background-thread write — a slow/unreachable database can never delay the game-over message reaching players.
- `python-dotenv` support: a local `.env` (gitignored, never committed — verified via `git log --all --full-history -- .env`) is loaded automatically at startup, so no manual `export` is needed for local dev. A real host (Render, etc.) has no `.env` file and just sets `DATABASE_URL` as its own environment variable/secret.
- README: full Supabase setup walkthrough.

## Verification
- Full suite: 236 passed (one pre-existing flaky test elsewhere, tracked separately on #9, not touched by this PR).
- Manually confirmed the server starts and keeps serving normally even when `DATABASE_URL` points at an unreachable database (caught and logged as a warning, not raised).
- End-to-end verified against a real Supabase project: played a real game through the browser, then queried Supabase directly and confirmed correct `games`/`player_games`/`players` rows (one human, one bot, linked correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gb2RNjMrzvVK13EP2aAnTK