### PR TITLE
Show /account/<username> in the URL bar

### DIFF
--- a/highsociety/web/static/js/account/account.js
+++ b/highsociety/web/static/js/account/account.js
@@ -496,7 +496,14 @@ export function showAccountScreen() {
   // guest, shouldn't flash the previous profile's feed for a moment).
   hide($('account-recent-activity-section'));
   showScreen('screen-account');
-  setScreenPath('/account');
+  // Includes the username (chess.com-style) purely for a nicer/shareable
+  // URL -- this is never a per-user viewer, so a stale or foreign
+  // username left over in the address bar (an old bookmark after a
+  // rename, say) just gets silently corrected to whoever's actually
+  // logged in on the very next visit, same as everything else this
+  // screen renders. Falls back to the bare path if somehow reached
+  // with no profile yet.
+  setScreenPath(profile ? `/account/${encodeURIComponent(profile.username)}` : '/account');
   // All three run independently/in parallel, same as the stats prefetch
   // already did -- none of them awaits or blocks another, so the screen's
   // fast initial paint (stats, from the login-time prefetch) is never held

--- a/highsociety/web/static/js/auth/login.js
+++ b/highsociety/web/static/js/auth/login.js
@@ -63,6 +63,14 @@ export function proceedPastLogin() {
     startPolling();
     return;
   }
+  // /account/<username> is a variant of /account (see web_server.py's own
+  // route comment) -- always the current browser's own profile, never a
+  // per-user viewer -- so it needs a prefix check rather than one exact-
+  // match BOOT_PATH_HANDLERS entry per possible username.
+  if (location.pathname.startsWith('/account/')) {
+    showAccountScreen();
+    return;
+  }
   const bootHandler = BOOT_PATH_HANDLERS[location.pathname];
   if (bootHandler) {
     bootHandler();

--- a/highsociety/web/static/js/utils/dom.js
+++ b/highsociety/web/static/js/utils/dom.js
@@ -40,7 +40,12 @@ export function setScreenPath(path) {
   // refresh at e.g. /join already has location.pathname === '/join' before
   // this ever runs, so gating this on the same "did it change" check would
   // leave a fresh page load with no sidebar tab highlighted at all.
-  setSidebarActive(SIDEBAR_ACTIVE_BY_PATH[path] || null);
+  // /account/<username> shares its sidebar highlight with the bare
+  // /account entry in SIDEBAR_ACTIVE_BY_PATH -- normalize the username
+  // segment away before the lookup rather than adding a second entry per
+  // possible username.
+  const sidebarLookupPath = path.startsWith('/account/') ? '/account' : path;
+  setSidebarActive(SIDEBAR_ACTIVE_BY_PATH[sidebarLookupPath] || null);
 }
 
 export function showScreen(id) {

--- a/tests/network/test_web_server.py
+++ b/tests/network/test_web_server.py
@@ -1896,12 +1896,18 @@ def test_rating_history_endpoint_returns_a_list(monkeypatch):
 
 # ---------------------------------------- static per-screen URLs --------
 
-@pytest.mark.parametrize("path", ["/", "/play", "/join", "/host", "/leaderboard", "/rules", "/account", "/achievements"])
+@pytest.mark.parametrize(
+    "path",
+    ["/", "/play", "/join", "/host", "/leaderboard", "/rules", "/account", "/account/alice", "/achievements"],
+)
 def test_static_screen_paths_all_serve_the_same_app_shell(path):
     """Each of the 7 top-level sidebar screens gets a real, refreshable/
     shareable URL (see app.js's SCREEN_PATHS/setScreenPath) -- all served
     by the same index() view as '/', since this is a single-page app that
-    figures out which screen to show client-side."""
+    figures out which screen to show client-side. /account/<username> is
+    the same Account screen with a cosmetic username segment -- the
+    username itself is never read server-side (see index()'s own
+    comment)."""
     resp = web_server.app.test_client().get(path)
     assert resp.status_code == 200
     assert b"High Society" in resp.data

--- a/web_server.py
+++ b/web_server.py
@@ -907,9 +907,17 @@ def api_rating_history(username):
 @app.route("/leaderboard")
 @app.route("/rules")
 @app.route("/account")
+@app.route("/account/<username>")
 @app.route("/achievements")
 @app.route("/my-games")
-def index():
+def index(username=None):
+    # The /account/<username> variant is purely cosmetic/shareable -- the
+    # account screen always renders whichever profile is actually logged
+    # in on this browser (there's no per-user public profile page), so
+    # `username` is never read here; the client corrects the URL bar to
+    # match the real logged-in profile regardless (see account.js's
+    # showAccountScreen), same as every other route on this one shared
+    # shell template.
     return render_template(
         "index.html", ga_measurement_id=GA_MEASUREMENT_ID,
         google_client_id=GOOGLE_CLIENT_ID if GOOGLE_SIGN_IN_ENABLED else None,


### PR DESCRIPTION
## Summary

The Account screen's URL is now `/account/<username>` (e.g. `/account/FakeUser`) instead of the bare `/account`, matching chess.com-style profile URLs. Purely cosmetic/shareable — there's no per-user public profile page, so the username segment is never read server-side; the screen always renders whichever profile is actually logged in on this browser and self-corrects the address bar if it doesn't match (e.g. an old bookmark after a rename).

- `web_server.py`: one more stacked route, `/account/<username>`, served by the same shell template as every other screen path.
- `account.js`: writes the username into the path when opening Account.
- `login.js`: boot-time direct-visit/refresh handling gets a prefix check for `/account/*`.
- `dom.js`: sidebar-highlight lookup normalizes the username segment away first, so Account's own highlight is unaffected.

## Testing

- Full backend suite: 523 passed (one new route-coverage test added).
- Verified live via Playwright: URL updates on opening Account, survives a refresh at that exact URL (sidebar highlight included), and a mismatched/stale username in the URL is corrected without breaking the render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)