### PR TITLE
Eagerly re-warm the leaderboard cache after a rated game

### DIFF
--- a/highsociety/code/common/db/game_history.py
+++ b/highsociety/code/common/db/game_history.py
@@ -999,42 +999,22 @@ _leaderboard_cache: dict = {}  # (limit, offset) -> (cached_at_monotonic, result
 _leaderboard_cache_lock = threading.Lock()
 
 
-def get_leaderboard(limit: int = 20, offset: int = 0) -> dict:
-    """
-    Page of players ranked by elo -- {"rows": [{"username", "elo",
-    "games_played", "games_won"}, ...], "has_more": bool}. Restricted to
-    Google-linked accounts (a guest's elo never moves off the 1000
-    default, so including them would just be a meaningless tie-heavy
-    list) and explicitly excluding the 3 reserved bot identities (see the
-    `bots` table): bots are real rated participants now (see record_
-    finished_game's own docstring) so their elo genuinely moves, but it
-    must never be shown to players. {"rows": [], "has_more": False} on
-    any failure or no database.
-
-    The leaderboard is the exact same data for every single visitor --
-    unlike everything else in this module, there's no per-user identity
-    involved at all, which makes it the cleanest possible caching target:
-    each (limit, offset) page is cached in memory for
-    _LEADERBOARD_CACHE_TTL_SECONDS and served with zero database
-    round-trips to every request that lands within that window, however
-    many concurrent visitors that is. 20s of staleness is imperceptible
-    for a leaderboard (nobody needs their rank to update mid-second) and
-    turns "the leaderboard should load instantly, it's the same for
-    everyone" from a database-latency problem into a non-problem.
-    """
-    cache_key = (limit, offset)
-    now = time.monotonic()
-    with _leaderboard_cache_lock:
-        cached = _leaderboard_cache.get(cache_key)
-    if cached is not None and now - cached[0] < _LEADERBOARD_CACHE_TTL_SECONDS:
-        return cached[1]
-
-    empty = {"rows": [], "has_more": False}
+def _fetch_leaderboard_page(limit: int, offset: int) -> Optional[dict]:
+    """The actual query behind one leaderboard page -- {"rows", "has_more"}
+    -- with no caching of its own. None (not the {"rows": [], ...} shape
+    get_leaderboard returns publicly) on any failure/no-database case, so
+    a caller like _warm_leaderboard_cache below can tell "genuinely
+    nothing to show" apart from "couldn't refresh it, leave the existing
+    cached copy alone" -- overwriting a good cached page with an empty
+    one on a transient DB hiccup would be strictly worse than just
+    leaving it stale a little longer. Split out of get_leaderboard so the
+    on-commit eager refresh (see record_finished_game) can populate the
+    cache with the exact same query instead of duplicating it."""
     if not is_configured():
-        return empty
+        return None
     ensure_schema()
     if not _schema_ready:
-        return empty
+        return None
     conn = None
     try:
         conn = _connect()
@@ -1058,17 +1038,74 @@ def get_leaderboard(limit: int = 20, offset: int = 0) -> dict:
                 {"username": u, "elo": e, "games_played": gp, "games_won": gw}
                 for u, e, gp, gw in all_rows[:limit]
             ]
-            result = {"rows": rows, "has_more": has_more}
+            return {"rows": rows, "has_more": has_more}
     except Exception as e:  # noqa: BLE001
-        LoggingManager.warning(f"game_history.get_leaderboard failed: {e}")
-        return empty
+        LoggingManager.warning(f"game_history._fetch_leaderboard_page failed: {e}")
+        return None
     finally:
         if conn is not None:
             _release_connection(conn)
 
+
+def get_leaderboard(limit: int = 20, offset: int = 0) -> dict:
+    """
+    Page of players ranked by elo -- {"rows": [{"username", "elo",
+    "games_played", "games_won"}, ...], "has_more": bool}. Restricted to
+    Google-linked accounts (a guest's elo never moves off the 1000
+    default, so including them would just be a meaningless tie-heavy
+    list) and explicitly excluding the 3 reserved bot identities (see the
+    `bots` table): bots are real rated participants now (see record_
+    finished_game's own docstring) so their elo genuinely moves, but it
+    must never be shown to players. {"rows": [], "has_more": False} on
+    any failure or no database.
+
+    The leaderboard is the exact same data for every single visitor --
+    unlike everything else in this module, there's no per-user identity
+    involved at all, which makes it the cleanest possible caching target:
+    each (limit, offset) page is cached in memory for
+    _LEADERBOARD_CACHE_TTL_SECONDS and served with zero database
+    round-trips to every request that lands within that window. That TTL
+    is just a safety net now, not the real staleness bound, though: the
+    moment a rated game actually finishes, record_finished_game clears
+    (and, for the default first page, immediately repopulates) this same
+    cache -- see _warm_leaderboard_cache's own docstring -- so in
+    practice almost nobody ever waits on either the TTL or a real query.
+    """
+    cache_key = (limit, offset)
+    now = time.monotonic()
+    with _leaderboard_cache_lock:
+        cached = _leaderboard_cache.get(cache_key)
+    if cached is not None and now - cached[0] < _LEADERBOARD_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    result = _fetch_leaderboard_page(limit, offset)
+    if result is None:
+        return {"rows": [], "has_more": False}
+
     with _leaderboard_cache_lock:
         _leaderboard_cache[cache_key] = (now, result)
     return result
+
+
+def _warm_leaderboard_cache() -> None:
+    """Called from record_finished_game's own background write thread the
+    instant a rated game commits, right after that same call already
+    cleared the cache (see there) -- re-runs the query immediately and
+    reinstalls the result, so the clear above doesn't just leave the next
+    real visitor to pay for a fresh fetch themselves. Only ever refills
+    the (20, 0) key -- the frontend's own default first page (see
+    leaderboard.js's PAGE_SIZE) and by far the overwhelming majority of
+    real views, since almost nobody actually pages past a small
+    leaderboard -- rather than trying to guess every (limit, offset) some
+    caller might have had cached; anything else just falls back to a
+    normal lazy fetch-on-next-request like before. Runs on a background
+    thread already, and this table is tiny, so the extra query here is
+    free in every way that matters to an actual player."""
+    result = _fetch_leaderboard_page(20, 0)
+    if result is None:
+        return  # leave the cache clear -- see _fetch_leaderboard_page's own docstring on why not to overwrite with a worse guess
+    with _leaderboard_cache_lock:
+        _leaderboard_cache[(20, 0)] = (time.monotonic(), result)
 
 
 def get_rating_history(username: str) -> list:
@@ -1701,11 +1738,18 @@ def record_finished_game(*, room_code: str, seats: int, bot_mix: list,
     if cache_refreshes:
         # A rated game just changed someone's standing -- don't make
         # everyone wait out the rest of the leaderboard's TTL to see it.
-        # Cheap regardless of how many pages are cached: worst case, the
-        # very next leaderboard view for each page pays one real query
-        # again instead of a cache hit.
+        # Clearing (not just the default page) covers every paginated
+        # offset someone might have cached, since a rank shift can move
+        # players across page boundaries too. _warm_leaderboard_cache
+        # then immediately re-fetches just the default first page, so
+        # the very next real visitor -- the overwhelmingly common case --
+        # gets a warm cache hit instead of paying for the query this
+        # clear would otherwise have pushed onto them. Runs on this same
+        # background write thread (see record_finished_game_async), so
+        # it costs a real player nothing either way.
         with _leaderboard_cache_lock:
             _leaderboard_cache.clear()
+        _warm_leaderboard_cache()
     return elo_changes
 
 

--- a/tests/common/test_game_history.py
+++ b/tests/common/test_game_history.py
@@ -1470,10 +1470,21 @@ def test_get_leaderboard_cache_is_scoped_per_page(database_url):
 
 def test_record_finished_game_invalidates_the_leaderboard_cache(database_url, mock_release_connection):
     """A rated game just changed someone's standing -- don't make every
-    visitor wait out the rest of the leaderboard's TTL to see it."""
+    visitor wait out the rest of the leaderboard's TTL to see it. Every
+    cached page is invalidated (a rank shift can move players across
+    page boundaries too), but the default first page is immediately
+    re-fetched and reinstalled -- see _warm_leaderboard_cache -- so the
+    very next real visitor gets a warm cache hit with fresh data instead
+    of the query this invalidation would otherwise have pushed onto
+    them."""
     game_history._schema_ready = True
     game_history._leaderboard_cache[(20, 0)] = (time.monotonic(), {"rows": ["stale"], "has_more": False})
+    game_history._leaderboard_cache[(20, 20)] = (time.monotonic(), {"rows": ["stale-page-2"], "has_more": False})
     conn, cursor = _fake_connection()
+    # record_finished_game itself never calls fetchall() (only fetchone(),
+    # for its own RETURNING-id upserts) -- this return_value is only ever
+    # actually consumed by _warm_leaderboard_cache's own leaderboard query.
+    cursor.fetchall = MagicMock(return_value=[("alice", 1016, 1, 1)])
     participants = [
         {"is_bot": False, "username": "alice", "name": "Alice", "game_username": "alice",
          "points": 10, "money_left": 5, "is_winner": True, "eliminated": False},
@@ -1489,6 +1500,25 @@ def test_record_finished_game_invalidates_the_leaderboard_cache(database_url, mo
             finished_at=datetime.datetime.now(datetime.timezone.utc),
             participants=participants,
         )
+    # The stale second page is gone, not silently kept around.
+    assert (20, 20) not in game_history._leaderboard_cache
+    # The default first page isn't just cleared -- it's already warm
+    # again with the freshly re-fetched result, not the old stale one.
+    assert (20, 0) in game_history._leaderboard_cache
+    _, warmed = game_history._leaderboard_cache[(20, 0)]
+    assert warmed == {"rows": [{"username": "alice", "elo": 1016, "games_played": 1, "games_won": 1}],
+                       "has_more": False}
+
+
+def test_warm_leaderboard_cache_leaves_it_clear_on_a_fetch_failure(database_url):
+    """A transient DB hiccup right after a game finishes shouldn't install
+    a worse (empty) result over what a normal lazy fetch would have
+    produced on the next real request -- see _fetch_leaderboard_page's
+    own docstring on why None (not an empty page) means "leave it
+    alone"."""
+    game_history._schema_ready = True
+    with patch.object(game_history, "_connect", side_effect=RuntimeError("db unreachable")):
+        game_history._warm_leaderboard_cache()
     assert (20, 0) not in game_history._leaderboard_cache
 
 


### PR DESCRIPTION
## Summary

The leaderboard already had two layers of caching: a 20s TTL, and (already, before this PR) an immediate cache-clear the instant a rated game commits, so nobody has to wait out the TTL to see a standing change. This closes the one remaining gap: clearing just pushed one real ~150ms query onto whichever visitor happened to load the leaderboard next. Now the default first page is re-fetched and reinstalled immediately, on the same background thread the game-finish write already runs on, so that visitor gets a warm cache hit instead.

- `_fetch_leaderboard_page`: the query itself, pulled out of `get_leaderboard` with no caching of its own — returns `None` (not an empty page) on failure, so a bad fetch can't overwrite a good cached page with a worse one.
- `_warm_leaderboard_cache`: re-fetches `(20, 0)` (the frontend's own default page, and the overwhelming majority of real views) and reinstalls it; a no-op if the fetch itself fails.
- `record_finished_game` calls it right after the existing cache clear.

Considered and ruled out: Redis. Measured against the real production DB first — this app runs as a single gunicorn worker, so the existing in-memory cache is already effectively shared across every visitor; the actual cost was network round-trip latency on a cache miss (~150ms, or ~3s on a cold connection pool), which Redis wouldn't reduce and would add its own network hop on top of. This fix targets what was actually measured.

## Testing

- Verified against the real DB: a cache hit after warming is ~0ms vs. ~150ms cold.
- Full backend suite: 524 passed (one new test for the fetch-failure no-op case, one existing test extended to check the warmed page's actual contents rather than just its absence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)