### PR TITLE
Public, read-only player profile pages (humans + bots)

### DIFF
--- a/highsociety/code/common/db/game_history.py
+++ b/highsociety/code/common/db/game_history.py
@@ -941,13 +941,25 @@ def get_recent_games(username: str, limit: int = 20, offset: int = 0) -> dict:
 def get_game_detail(game_id: int) -> Optional[dict]:
     """
     Full per-participant breakdown of one game -- {"game_id",
-    "finished_at", "participants": [{"name", "is_bot", "points",
-    "money_left", "is_winner", "eliminated", "placement"}, ...]},
-    ordered by placement. No access check tied to any particular
-    username -- consistent with this app's existing stateless,
-    sessionless trust model (e.g. /api/auth/username/change's own
-    docstring), and a finished game's results aren't sensitive. None if
-    the game_id doesn't exist or on any failure.
+    "finished_at", "participants": [{"name", "is_bot",
+    "bot_profile_username", "points", "money_left", "is_winner",
+    "eliminated", "placement"}, ...]}, ordered by placement. No access
+    check tied to any particular username -- consistent with this app's
+    existing stateless, sessionless trust model (e.g.
+    /api/auth/username/change's own docstring), and a finished game's
+    results aren't sensitive. None if the game_id doesn't exist or on any
+    failure.
+
+    `bot_profile_username` is a second, deliberately separate lookup from
+    `name`: `name` stays this seat's own per-game flavor label (e.g.
+    "Ziggy bot", from `pg.bot_name`) so the row itself never changes, but
+    a bot with a known difficulty also has a real, shared players row
+    (see the `bots` table) with genuine aggregate stats -- this is that
+    row's username (one of `__bot_easy__`/`__bot_medium__`/`__bot_hard__`),
+    for the caller to link the name to a real profile. None for a human
+    participant, or for a bot with no known difficulty (nothing to link
+    to -- see record_finished_game's own docstring on `difficulty` being
+    optional).
     """
     if not is_configured():
         return None
@@ -972,18 +984,22 @@ def get_game_detail(game_id: int) -> Optional[dict]:
             cur.execute(
                 """
                 SELECT COALESCE(p.username, pg.bot_name) AS name, p.id IS NULL AS is_bot,
+                       bot_p.username AS bot_profile_username,
                        pg.points, pg.money_left, pg.is_winner, pg.eliminated, pg.placement
                 FROM player_games pg
                 LEFT JOIN players p ON p.id = pg.player_id AND p.id NOT IN (SELECT player_id FROM bots)
+                LEFT JOIN players bot_p ON bot_p.id = pg.player_id AND bot_p.id IN (SELECT player_id FROM bots)
                 WHERE pg.game_id = %s
                 ORDER BY pg.placement NULLS LAST
                 """,
                 (game_id,),
             )
             participants = [
-                {"name": name, "is_bot": is_bot, "points": points, "money_left": money_left,
+                {"name": name, "is_bot": is_bot, "bot_profile_username": bot_profile_username,
+                 "points": points, "money_left": money_left,
                  "is_winner": is_winner, "eliminated": eliminated, "placement": placement}
-                for name, is_bot, points, money_left, is_winner, eliminated, placement in cur.fetchall()
+                for name, is_bot, bot_profile_username, points, money_left, is_winner, eliminated, placement
+                in cur.fetchall()
             ]
             return {"game_id": game_id, "finished_at": finished_at.isoformat(), "participants": participants}
     except Exception as e:  # noqa: BLE001

--- a/highsociety/web/static/js/app.js
+++ b/highsociety/web/static/js/app.js
@@ -2,7 +2,9 @@
 // DOMContentLoaded. Owns nothing itself -- every handler it wires lives in
 // its own feature module; this file only imports and attaches them.
 import { $, showScreen } from './utils/dom.js';
-import { resolveConfirmDialog, openProfileModal, closeProfileModal, closeGameDetailModal } from './ui/modals.js';
+import {
+  resolveConfirmDialog, openProfileModal, closeProfileModal, closeGameDetailModal, onGameDetailTableClick,
+} from './ui/modals.js';
 import { onSpecChatSend, onPlayerChatSend } from './ui/chat.js';
 import {
   onContinueAsGuest, onShuffleUsername, onLoginUsernameContinue, initGoogleSignIn, proceedPastLogin,
@@ -25,7 +27,12 @@ import { onAddBot } from './lobby/playerList.js';
 import {
   showGameHistoryScreen, onGameHistoryPrevClick, onGameHistoryNextClick, getGameHistoryReturnTo,
 } from './lobby/gameHistory.js';
-import { showLeaderboardScreen, onLeaderboardPrevClick, onLeaderboardNextClick } from './lobby/leaderboard.js';
+import {
+  showLeaderboardScreen, onLeaderboardPrevClick, onLeaderboardNextClick, onLeaderboardTableClick,
+} from './lobby/leaderboard.js';
+import {
+  getPlayerProfileReturnTo, onPlayerProfileHistoryPrevClick, onPlayerProfileHistoryNextClick,
+} from './lobby/playerProfile.js';
 import { onPlayClick, onFindMatch, onMatchmakingCancel, onMatchmakingAddBots } from './lobby/matchmaking.js';
 import {
   onRequestRematchClick, onCancelRematchForm, onSendRematchRequest, onAcceptRematch, onDeclineRematch,
@@ -142,6 +149,18 @@ function wireStaticHandlers() {
   $('sidebar-leaderboard').addEventListener('click', () => navigateFromSidebar(showLeaderboardScreen));
   $('btn-leaderboard-prev').addEventListener('click', onLeaderboardPrevClick);
   $('btn-leaderboard-next').addEventListener('click', onLeaderboardNextClick);
+  $('leaderboard-body').addEventListener('click', onLeaderboardTableClick);
+  $('game-detail-body').addEventListener('click', onGameDetailTableClick);
+  // Reached from a name click (Leaderboard or the game detail modal), not
+  // the sidebar -- Back returns to whichever one was actually used
+  // (getPlayerProfileReturnTo, same "returnTo" idea as Game History's own
+  // multi-entry-point Back button above).
+  $('btn-player-profile-back').addEventListener('click', () => navigateFromSidebar(() => {
+    if (getPlayerProfileReturnTo() === 'leaderboard') showLeaderboardScreen();
+    else { showScreen('screen-host-setup'); showHomeTiles(); startRoomsPolling(); }
+  }));
+  $('btn-player-profile-history-prev').addEventListener('click', onPlayerProfileHistoryPrevClick);
+  $('btn-player-profile-history-next').addEventListener('click', onPlayerProfileHistoryNextClick);
   $('game-detail-close').addEventListener('click', closeGameDetailModal);
   $('btn-account-save').addEventListener('click', onAccountSaveClick);
   $('btn-account-edit-username').addEventListener('click', onAccountEditUsernameClick);

--- a/highsociety/web/static/js/auth/login.js
+++ b/highsociety/web/static/js/auth/login.js
@@ -7,6 +7,7 @@ import { saveProfile, renderProfileChip } from './profile.js';
 import { prefetchAccountStats, showAccountScreen, showAchievementsScreen } from '../account/account.js';
 import { showLeaderboardScreen } from '../lobby/leaderboard.js';
 import { showGameHistoryScreen } from '../lobby/gameHistory.js';
+import { showPlayerProfileScreen } from '../lobby/playerProfile.js';
 import { onPlayClick } from '../lobby/matchmaking.js';
 
 // Maps a direct/refreshed visit to one of the 8 static screen URLs
@@ -69,6 +70,15 @@ export function proceedPastLogin() {
   // match BOOT_PATH_HANDLERS entry per possible username.
   if (location.pathname.startsWith('/account/')) {
     showAccountScreen();
+    return;
+  }
+  // /players/<username> carries a real per-user segment (unlike every
+  // other entry in BOOT_PATH_HANDLERS below, which are all exact-match
+  // static paths) -- a direct visit/refresh/shared link at this URL
+  // opens that exact profile, same as clicking their name anywhere else.
+  if (location.pathname.startsWith('/players/')) {
+    const username = decodeURIComponent(location.pathname.slice('/players/'.length));
+    showPlayerProfileScreen(username, 'leaderboard');
     return;
   }
   const bootHandler = BOOT_PATH_HANDLERS[location.pathname];

--- a/highsociety/web/static/js/lobby/leaderboard.js
+++ b/highsociety/web/static/js/lobby/leaderboard.js
@@ -8,6 +8,7 @@ import { $, hide, show, showScreen, setScreenPath } from '../utils/dom.js';
 import { escapeHtml } from '../utils/formatting.js';
 import { loadProfile } from '../auth/profile.js';
 import { fetchJSON } from './lobby.js';
+import { showPlayerProfileScreen } from './playerProfile.js';
 
 const PAGE_SIZE = 20;
 let leaderboardOffset = 0;
@@ -58,7 +59,7 @@ async function loadLeaderboardPage(profile) {
       return `
       <tr class="${profile && r.username === profile.username ? 'leaderboard-row-me' : ''}">
         <td class="${rank === 1 ? 'leaderboard-rank-1' : ''}">${rank}</td>
-        <td>${escapeHtml(r.username)}</td>
+        <td><button type="button" class="name-link" data-username="${escapeHtml(r.username)}">${escapeHtml(r.username)}</button></td>
         <td>${r.elo}</td>
         <td>${r.games_played}</td>
         <td>${r.games_won}</td>
@@ -73,4 +74,13 @@ async function loadLeaderboardPage(profile) {
     body.innerHTML = '';
     show(empty);
   }
+}
+
+// Every ranked player's name opens their real public profile page --
+// "self-explanatory" per the original ask, since this table is already
+// nothing but real, rated humans (see get_leaderboard's own docstring on
+// why guests/bots are excluded here).
+export function onLeaderboardTableClick(e) {
+  const btn = e.target.closest('[data-username]');
+  if (btn) showPlayerProfileScreen(btn.dataset.username, 'leaderboard');
 }

--- a/highsociety/web/static/js/lobby/playerProfile.js
+++ b/highsociety/web/static/js/lobby/playerProfile.js
@@ -1,0 +1,135 @@
+// Public, read-only player profile screen -- any human player, or one of
+// the 3 reserved bot identities (see web_server.py's BOT_PROFILES).
+// Deliberately separate from account.js's own screen: /account only ever
+// shows whoever's logged in on this browser and lets them edit it; this
+// one is a pure viewer of *anyone*, reached by clicking a name on the
+// Leaderboard (leaderboard.js) or in the game detail modal
+// (ui/modals.js), with no edit affordances at all.
+import { $, hide, show, showScreen, setScreenPath } from '../utils/dom.js';
+import { timeAgo } from '../utils/formatting.js';
+import { fetchJSON } from './lobby.js';
+import { fetchGamesPage, renderIfChanged } from './gameHistory.js';
+
+const PAGE_SIZE = 10; // matches gameHistory.js's own fixed page size -- fetchGamesPage bakes this in already
+
+const dateLabel = (iso) => new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+let profileUsername = null; // the profile currently shown/loading -- stale-response guard for both loaders below
+let profileOffset = 0;
+// Where the Back button returns to -- this screen has two real entry
+// points (Leaderboard, the game detail modal opened from anywhere), same
+// "returnTo" idea gameHistory.js already established for its own Back
+// button's identical multi-entry-point problem.
+let profileReturnTo = 'leaderboard';
+
+export function getPlayerProfileReturnTo() {
+  return profileReturnTo;
+}
+
+export function showPlayerProfileScreen(username, returnTo = 'leaderboard') {
+  profileUsername = username;
+  profileOffset = 0;
+  profileReturnTo = returnTo;
+  showScreen('screen-player-profile');
+  setScreenPath(`/players/${encodeURIComponent(username)}`);
+
+  $('player-profile-avatar').textContent = username.charAt(0).toUpperCase();
+  $('player-profile-name').textContent = username;
+  hide($('player-profile-bio'));
+  hide($('player-profile-meta-row'));
+  hide($('player-profile-elo-hero'));
+  $('player-profile-stats-row').classList.add('loading');
+  hide($('player-profile-history-section'));
+  $('player-profile-history-list').innerHTML = '';
+  delete $('player-profile-history-list').dataset.renderedHtml; // a stale renderIfChanged memo from a *different* profile must never suppress this one's first real paint
+
+  loadPlayerProfileStats(username);
+  loadPlayerProfileHistoryPage();
+}
+
+async function loadPlayerProfileStats(username) {
+  let stats;
+  try {
+    stats = await fetchJSON(`/api/profile/${encodeURIComponent(username)}`);
+  } catch (e) {
+    // No games recorded yet (a brand new guest, or a typo'd username) --
+    // a real, honest outcome, not an error: leave the placeholder name/
+    // avatar up and the stat cards at their "—" default.
+    if (username === profileUsername) $('player-profile-stats-row').classList.remove('loading');
+    return;
+  }
+  if (username !== profileUsername) return; // navigated to a different profile before this resolved
+
+  $('player-profile-avatar').textContent = stats.display_name.charAt(0).toUpperCase();
+  $('player-profile-name').textContent = stats.display_name;
+  $('player-profile-elo').textContent = stats.elo;
+  show($('player-profile-elo-hero'));
+
+  if (stats.is_bot) {
+    // A bot never "joined" -- player-since/last-played would just read as
+    // "since this table's schema was created", so a bit of flavor text
+    // takes that slot instead (see BOT_PROFILES' own comment).
+    $('player-profile-bio').textContent = stats.bio;
+    show($('player-profile-bio'));
+  } else {
+    $('player-profile-since').textContent = dateLabel(stats.created_at);
+    $('player-profile-last-played').textContent = stats.last_played_at ? timeAgo(stats.last_played_at) : '—';
+    show($('player-profile-meta-row'));
+  }
+
+  $('player-profile-stat-games').textContent = stats.games_played;
+  $('player-profile-stat-wins').textContent = stats.wins;
+  $('player-profile-stat-winrate').textContent = `${Math.round(stats.win_rate * 100)}%`;
+  $('player-profile-stat-avg-placement').textContent = stats.avg_placement != null ? stats.avg_placement.toFixed(1) : '—';
+  $('player-profile-stat-avg-points').textContent = stats.avg_points != null ? stats.avg_points.toFixed(1) : '—';
+  $('player-profile-stat-avg-money').textContent = stats.avg_money_remaining != null ? stats.avg_money_remaining.toFixed(1) : '—';
+  $('player-profile-stats-row').classList.remove('loading');
+}
+
+// Paginated (10 per page, Prev/Next) exactly like the My Games screen --
+// "potentially all their games", not just a short teaser -- reusing that
+// same fetchGamesPage/renderIfChanged pair (see gameHistory.js's own
+// module comment) so this list looks and behaves identically everywhere
+// it appears, not a fourth parallel implementation.
+async function loadPlayerProfileHistoryPage() {
+  const username = profileUsername;
+  const offset = profileOffset;
+  const { cached, freshPromise } = fetchGamesPage(username, offset);
+  if (cached) paintPlayerProfileHistoryPage(cached, username, offset);
+  const fresh = await freshPromise;
+  if (username !== profileUsername || offset !== profileOffset) return; // Prev/Next (or a whole new profile) already moved on
+  if (fresh) paintPlayerProfileHistoryPage(fresh, username, offset);
+  else if (!cached) {
+    hide($('player-profile-history-section'));
+  }
+}
+
+function paintPlayerProfileHistoryPage(page, username, offset) {
+  const section = $('player-profile-history-section');
+  const list = $('player-profile-history-list');
+  const empty = $('player-profile-history-empty');
+  const pagination = $('player-profile-history-pagination');
+  show(section);
+  if (page.games.length === 0 && offset === 0) {
+    list.innerHTML = '';
+    show(empty);
+    hide(pagination);
+    return;
+  }
+  hide(empty);
+  renderIfChanged(list, page.games, username);
+  $('btn-player-profile-history-prev').disabled = offset === 0;
+  $('btn-player-profile-history-next').disabled = !page.has_more;
+  $('player-profile-history-page-label').textContent = `${offset + 1}–${offset + page.games.length}`;
+  show(pagination);
+}
+
+export function onPlayerProfileHistoryPrevClick() {
+  profileOffset = Math.max(0, profileOffset - PAGE_SIZE);
+  loadPlayerProfileHistoryPage();
+}
+
+export function onPlayerProfileHistoryNextClick() {
+  profileOffset += PAGE_SIZE;
+  loadPlayerProfileHistoryPage();
+}

--- a/highsociety/web/static/js/ui/modals.js
+++ b/highsociety/web/static/js/ui/modals.js
@@ -2,6 +2,14 @@
 import { $, hide, show } from '../utils/dom.js';
 import { escapeHtml } from '../utils/formatting.js';
 import { fetchJSON } from '../lobby/lobby.js';
+// Circular with gameHistory.js (which imports openGameDetailModal from
+// here) via playerProfile.js's own import of fetchGamesPage/renderIfChanged
+// from gameHistory.js -- safe by this project's own established
+// convention (see gameHistory.js's identical note on this exact pair):
+// every side of the cycle only ever touches another side's export inside
+// a function body (onGameDetailTableClick below; wireRowClicks in
+// gameHistory.js), never at any module's own top-level evaluation.
+import { showPlayerProfileScreen } from '../lobby/playerProfile.js';
 
 // In-page confirm dialog (resign, leaving mid-game — see gameActions.js's
 // onResign/lobby.js's onHomeLinkClick) styled like every other panel in the
@@ -65,16 +73,41 @@ export async function openGameDetailModal(gameId) {
   try {
     const detail = await fetchJSON(`/api/games/detail/${encodeURIComponent(gameId)}`);
     $('game-detail-date').textContent = new Date(detail.finished_at).toLocaleDateString();
-    body.innerHTML = detail.participants.map((p) => `
+    body.innerHTML = detail.participants.map((p) => {
+      // A human's own name is always a real, linkable username. A bot's
+      // displayed name is a per-seat flavor label ("Ziggy bot") that
+      // never had a profile of its own -- bot_profile_username (see
+      // get_game_detail's own docstring) is the shared difficulty
+      // identity's real username to link to instead, when this game
+      // actually recorded one (older games might not have).
+      const linkUsername = p.is_bot ? p.bot_profile_username : p.name;
+      const nameHtml = linkUsername
+        ? `<button type="button" class="name-link" data-username="${escapeHtml(linkUsername)}">${escapeHtml(p.name)}</button>`
+        : escapeHtml(p.name);
+      return `
       <tr>
         <td>${p.placement != null ? p.placement : '—'}</td>
-        <td>${escapeHtml(p.name)}${p.is_bot ? ' (bot)' : ''}${p.is_winner ? ' 🏆' : ''}</td>
+        <td>${nameHtml}${p.is_bot ? ' (bot)' : ''}${p.is_winner ? ' 🏆' : ''}</td>
         <td>${p.points}</td>
         <td>${p.money_left}</td>
       </tr>
-    `).join('');
+    `;
+    }).join('');
   } catch (e) {
     body.innerHTML = '<tr><td colspan="4">Could not load this game.</td></tr>';
   }
 }
 export function closeGameDetailModal() { hide($('game-detail-modal')); }
+
+// Wired from index.html's game-detail-body click delegation (see app.js,
+// same data-attribute-click-delegation pattern rematch.js's own
+// onStandingsTableClick already uses for its own name links). Closing
+// the modal first, then navigating, matches what closing it always did
+// anyway -- this just also happens to land somewhere instead of nowhere.
+export function onGameDetailTableClick(e) {
+  const btn = e.target.closest('[data-username]');
+  if (btn) {
+    closeGameDetailModal();
+    showPlayerProfileScreen(btn.dataset.username, 'leaderboard');
+  }
+}

--- a/highsociety/web/static/js/utils/constants.js
+++ b/highsociety/web/static/js/utils/constants.js
@@ -34,7 +34,7 @@ export const SIDEBAR_HIDDEN_SCREENS = new Set(['screen-login', 'screen-game']);
 // than once on every "back to home" navigation).
 export const GLOBAL_STATS_FOOTER_SCREENS = new Set([
   'screen-matchmaking', 'screen-leaderboard',
-  'screen-account', 'screen-achievements', 'screen-game-history',
+  'screen-account', 'screen-achievements', 'screen-game-history', 'screen-player-profile',
 ]);
 
 // Maps setScreenPath's own path argument to the sidebar item it should
@@ -66,6 +66,10 @@ export const SIDEBAR_ACTIVE_BY_PATH = {
 // otherwise still sitting underneath.
 export const SIDEBAR_ACTIVE_CLEARING_SCREENS = new Set([
   'screen-join', 'screen-spectate-join', 'screen-spectate', 'screen-finished', 'screen-game',
+  // Reached from a name click (Leaderboard or a game detail modal), not
+  // from the sidebar itself -- no sidebar item describes "you're looking
+  // at some specific player's profile", so nothing should stay lit.
+  'screen-player-profile',
 ]);
 
 const TOAST_DURATION_MS = 1500; // long enough to actually read before it clears

--- a/highsociety/web/templates/index.html
+++ b/highsociety/web/templates/index.html
@@ -465,6 +465,129 @@
       </div>
     </section>
 
+    <!-- ===================== PLAYER PROFILE (public, read-only) =====================
+         Any player (or the 3 reserved bot identities -- see web_server.py's
+         BOT_PROFILES), reached by clicking a name on the Leaderboard or in the
+         game detail modal -- see playerProfile.js. Deliberately separate from
+         /account: that screen only ever shows whoever's logged in on this
+         browser and lets them edit it; this one is a read-only viewer of
+         *anyone*, with no edit affordances at all. -->
+    <section id="screen-player-profile" class="screen hidden">
+      <div class="account-screen-wrap">
+        <button type="button" class="screen-back" id="btn-player-profile-back">← Back</button>
+
+        <div class="card panel account-panel">
+          <div class="account-header">
+            <span id="player-profile-avatar" class="profile-chip-avatar account-avatar"></span>
+            <div>
+              <h2 id="player-profile-name"></h2>
+              <div id="player-profile-elo-hero" class="account-elo-hero hidden">
+                <span id="player-profile-elo" class="account-elo-value"></span> <span class="account-elo-label">ELO RATING</span>
+              </div>
+            </div>
+          </div>
+          <!-- Bots get a bit of flavor text instead of the player-since/
+               last-played meta a human profile shows -- both would just
+               read as "since the schema was created" for a shared identity
+               that never actually joined (see BOT_PROFILES' own comment). -->
+          <p id="player-profile-bio" class="muted hidden"></p>
+          <div id="player-profile-meta-row" class="account-meta-row hidden">
+            <span class="account-meta-item">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <rect x="3.5" y="5" width="17" height="15.5" rx="1.5"/><path d="M3.5 9.5h17"/><path d="M8 3v3.5M16 3v3.5"/>
+              </svg>
+              <span>Player since <span id="player-profile-since"></span></span>
+            </span>
+            <span class="account-meta-item">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="9"/><path d="M12 7.5V12l3 2"/>
+              </svg>
+              <span>Last played <span id="player-profile-last-played"></span></span>
+            </span>
+          </div>
+
+          <div id="player-profile-stats-row" class="account-stats-row account-stats-grid loading">
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="4" y="4" width="16" height="16" rx="3"/>
+                  <circle cx="8.5" cy="8.5" r="1.2" fill="currentColor" stroke="none"/>
+                  <circle cx="12" cy="12" r="1.2" fill="currentColor" stroke="none"/>
+                  <circle cx="15.5" cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
+                </svg>
+              </span>
+              <span id="player-profile-stat-games" class="account-stat-value">—</span>
+              <span class="account-stat-label">Games played</span>
+            </div>
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                  <path d="M12 3.4l2.5 5.4 5.9.6-4.4 4 1.3 5.8L12 16.2l-5.3 3-1.3.9 1.3-5.8-4.4-4 5.9-.6z"/>
+                </svg>
+              </span>
+              <span id="player-profile-stat-wins" class="account-stat-value">—</span>
+              <span class="account-stat-label">Wins</span>
+            </div>
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="8.3"/><circle cx="12" cy="12" r="4.3"/><circle cx="12" cy="12" r="1" fill="currentColor" stroke="none"/>
+                </svg>
+              </span>
+              <span id="player-profile-stat-winrate" class="account-stat-value">—</span>
+              <span class="account-stat-label">Win rate</span>
+            </div>
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="3.5" y="14.5" width="4.5" height="6" rx="1"/><rect x="9.75" y="9.5" width="4.5" height="11" rx="1"/><rect x="16" y="4.5" width="4.5" height="16" rx="1"/>
+                </svg>
+              </span>
+              <span id="player-profile-stat-avg-placement" class="account-stat-value">—</span>
+              <span class="account-stat-label">Avg. placement</span>
+            </div>
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                  <path d="M12 3l7 7-7 11-7-11z"/>
+                </svg>
+              </span>
+              <span id="player-profile-stat-avg-points" class="account-stat-value">—</span>
+              <span class="account-stat-label">Avg. points</span>
+            </div>
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="8.3"/>
+                  <path d="M12 7.5v9M9.3 9.4c0-1.1 1-2 2.7-2s2.7.9 2.7 1.9c0 2.6-5.4 1.4-5.4 4 0 1.1 1.2 2 2.7 2s2.7-.8 2.7-1.9"/>
+                </svg>
+              </span>
+              <span id="player-profile-stat-avg-money" class="account-stat-value">—</span>
+              <span class="account-stat-label">Avg. money left</span>
+            </div>
+          </div>
+        </div>
+
+        <div id="player-profile-history-section" class="card panel account-panel hidden">
+          <h3>
+            <span class="section-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="8.3"/><path d="M12 7.5V12l3 2"/>
+              </svg>
+            </span>
+            Game History
+          </h3>
+          <div id="player-profile-history-list" class="recent-games-list"></div>
+          <p id="player-profile-history-empty" class="muted hidden">No games recorded yet.</p>
+          <div id="player-profile-history-pagination" class="leaderboard-pagination hidden">
+            <button type="button" id="btn-player-profile-history-prev" class="secondary" disabled>← Prev</button>
+            <span id="player-profile-history-page-label" class="muted"></span>
+            <button type="button" id="btn-player-profile-history-next" class="secondary" disabled>Next →</button>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- ===================== LEADERBOARD ===================== -->
     <section id="screen-leaderboard" class="screen hidden">
       <div class="card panel account-panel leaderboard-panel">

--- a/tests/common/test_game_history.py
+++ b/tests/common/test_game_history.py
@@ -1347,17 +1347,21 @@ def test_get_game_detail_returns_every_participant_ordered_by_placement(database
     cursor.fetchone.side_effect = None
     cursor.fetchone.return_value = (finished_at,)
     cursor.fetchall = MagicMock(return_value=[
-        ("alice", False, 15, 5, True, False, 1),
-        ("Marble", True, 5, 0, False, True, 2),
+        ("alice", False, None, 15, 5, True, False, 1),
+        ("Marble", True, "__bot_hard__", 5, 0, False, True, 2),
     ])
     with patch.object(game_history, "_connect", return_value=conn):
         result = game_history.get_game_detail(42)
     assert result["game_id"] == 42
     assert len(result["participants"]) == 2
     assert result["participants"][0] == {
-        "name": "alice", "is_bot": False, "points": 15, "money_left": 5,
+        "name": "alice", "is_bot": False, "bot_profile_username": None, "points": 15, "money_left": 5,
         "is_winner": True, "eliminated": False, "placement": 1,
     }
+    # The bot seat's flavor name ("Marble") is untouched, but it also
+    # carries the shared difficulty identity's real username to link to.
+    assert result["participants"][1]["name"] == "Marble"
+    assert result["participants"][1]["bot_profile_username"] == "__bot_hard__"
 
 
 def test_get_game_detail_reads_placement_from_player_games_not_game_results(database_url):

--- a/tests/network/test_web_server.py
+++ b/tests/network/test_web_server.py
@@ -1797,7 +1797,26 @@ def test_profile_endpoint_returns_stats_and_elo(monkeypatch):
         "username": "alice", "games_played": 4, "wins": 3, "win_rate": 0.75,
         "avg_placement": 1.5, "avg_points": 12.0, "avg_money_remaining": 6.0, "elo": 1032,
         "created_at": "2025-06-01T00:00:00+00:00", "last_played_at": "2026-03-15T00:00:00+00:00",
+        "is_bot": False, "display_name": "alice", "bio": None,
     }
+
+
+def test_profile_endpoint_flags_the_reserved_bot_identities(monkeypatch):
+    """The 3 shared bot-difficulty identities (see web_server.py's own
+    BOT_PROFILES) get a friendlier display name and a bit of flavor text
+    instead of the raw "__bot_hard__" username -- real stats otherwise,
+    same as any human."""
+    monkeypatch.setattr(game_history, "get_player_profile_stats", lambda username: {
+        "games_played": 500, "wins": 210, "win_rate": 0.42, "elo": 1140,
+        "avg_placement": 2.1, "avg_points": 15.0, "avg_money_remaining": 3.0,
+        "created_at": "2025-01-01T00:00:00+00:00", "last_played_at": "2026-03-15T00:00:00+00:00",
+    })
+    resp = web_server.app.test_client().get("/api/profile/__bot_hard__")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["is_bot"] is True
+    assert body["display_name"] == "Hard Bot"
+    assert isinstance(body["bio"], str) and len(body["bio"]) > 0
 
 
 def test_global_stats_endpoint_returns_204_when_unavailable(monkeypatch):
@@ -1898,7 +1917,10 @@ def test_rating_history_endpoint_returns_a_list(monkeypatch):
 
 @pytest.mark.parametrize(
     "path",
-    ["/", "/play", "/join", "/host", "/leaderboard", "/rules", "/account", "/account/alice", "/achievements"],
+    [
+        "/", "/play", "/join", "/host", "/leaderboard", "/rules", "/account", "/account/alice",
+        "/achievements", "/players/alice",
+    ],
 )
 def test_static_screen_paths_all_serve_the_same_app_shell(path):
     """Each of the 7 top-level sidebar screens gets a real, refreshable/
@@ -1907,7 +1929,9 @@ def test_static_screen_paths_all_serve_the_same_app_shell(path):
     figures out which screen to show client-side. /account/<username> is
     the same Account screen with a cosmetic username segment -- the
     username itself is never read server-side (see index()'s own
-    comment)."""
+    comment). /players/<username> is the one route here with a real
+    per-user destination -- the username itself still isn't read
+    server-side either."""
     resp = web_server.app.test_client().get(path)
     assert resp.status_code == 200
     assert b"High Society" in resp.data

--- a/web_server.py
+++ b/web_server.py
@@ -807,16 +807,48 @@ def api_achievements():
     return jsonify({"achievements": game_history.get_player_achievements(username)})
 
 
+
+# The 3 reserved per-difficulty bot identities (see game_history.py's own
+# schema comment for `players`/`bots`) get a public profile too -- real
+# aggregate stats already exist for them (bots are real rated
+# participants, see record_finished_game's docstring), they just need a
+# friendlier display name than the internal "__bot_easy__" username and
+# a bit of flavor text in place of the "player since"/"last played" meta
+# a human profile shows (both would just read as "since the schema was
+# created", which is meaningless for a shared identity that never
+# actually "joined"). Deliberately presentation-only content, kept here
+# rather than in game_history.py, which stays a plain persistence layer
+# with no opinion on bio copy.
+BOT_PROFILES = {
+    "__bot_easy__": {
+        "display_name": "Easy Bot",
+        "bio": "Bids first, thinks never. A creature of pure impulse and modest budgets.",
+    },
+    "__bot_medium__": {
+        "display_name": "Medium Bot",
+        "bio": "Reads the table, mostly. Occasionally overpays for a Painting out of spite.",
+    },
+    "__bot_hard__": {
+        "display_name": "Hard Bot",
+        "bio": "Counts your money better than you do. Shows no mercy and even less small talk.",
+    },
+}
+
+
 @app.route("/api/profile/<username>")
 def api_profile(username):
     """Public profile stats -- games played, win rate, current Elo.
     Unlike achievements this isn't gated to Google-linked accounts (see
     get_player_profile_stats's own docstring): it's just a factual record
     of games already played under this exact username, visible to anyone,
-    matching the user's own "should be publicly visible" ask."""
+    matching the user's own "should be publicly visible" ask. Also
+    answers for the 3 reserved bot identities (see BOT_PROFILES above) --
+    same shape, plus is_bot/display_name/bio so the client can render a
+    bot's profile distinctly from a human's."""
     stats = game_history.get_player_profile_stats(username)
     if stats is None:
         return jsonify({"error": "No games recorded for that username yet."}), 404
+    bot_profile = BOT_PROFILES.get(username)
     return jsonify({
         "username": username,
         "games_played": stats["games_played"],
@@ -828,6 +860,9 @@ def api_profile(username):
         "elo": stats["elo"],
         "created_at": stats["created_at"],
         "last_played_at": stats["last_played_at"],
+        "is_bot": bot_profile is not None,
+        "display_name": bot_profile["display_name"] if bot_profile else username,
+        "bio": bot_profile["bio"] if bot_profile else None,
     })
 
 
@@ -910,14 +945,21 @@ def api_rating_history(username):
 @app.route("/account/<username>")
 @app.route("/achievements")
 @app.route("/my-games")
+@app.route("/players/<username>")
 def index(username=None):
-    # The /account/<username> variant is purely cosmetic/shareable -- the
-    # account screen always renders whichever profile is actually logged
-    # in on this browser (there's no per-user public profile page), so
-    # `username` is never read here; the client corrects the URL bar to
-    # match the real logged-in profile regardless (see account.js's
-    # showAccountScreen), same as every other route on this one shared
-    # shell template.
+    # Two different routes share this same `username` param, for two
+    # different reasons -- neither actually reads it here:
+    # - /account/<username> is purely cosmetic/shareable -- the account
+    #   screen always renders whichever profile is actually logged in on
+    #   this browser (there's no per-user account editor), so the client
+    #   corrects the URL bar to match the real logged-in profile
+    #   regardless (see account.js's showAccountScreen).
+    # - /players/<username> is a real per-player public page (unlike
+    #   /account) -- the client reads it back out of location.pathname
+    #   itself instead (see playerProfile.js's showPlayerProfileScreen/
+    #   its own boot-path handling).
+    # Both are otherwise the same client-decides-what-to-show model every
+    # other route on this one shared shell template already uses.
     return render_template(
         "index.html", ga_measurement_id=GA_MEASUREMENT_ID,
         google_client_id=GOOGLE_CLIENT_ID if GOOGLE_SIGN_IN_ENABLED else None,


### PR DESCRIPTION
## Summary

Answers "is this possible?" -- yes. New `/players/<username>` screen showing stats/Elo/game history for any player, reached by clicking a name on the Leaderboard or in the game detail modal. Includes the 3 reserved bot identities, each with a friendly display name and a bit of flavor text instead of a meaningless "player since" date.

- **Leaderboard**: every row's name is now a real link to that player's profile.
- **Game detail modal** (opened from My Games / Home / Account / this same screen's own game history): each participant's name links too -- a human's own username always works; a bot's per-seat flavor name (e.g. "Ziggy bot") links to its shared difficulty identity's real profile (`__bot_easy__`/`__bot_medium__`/`__bot_hard__`) whenever that game recorded one.
- **Bots get real stats** -- games played, wins, win rate, Elo, all genuine (bots are real rated participants already) -- plus a bio:
  - Easy Bot: *"Bids first, thinks never. A creature of pure impulse and modest budgets."*
  - Medium Bot: *"Reads the table, mostly. Occasionally overpays for a Painting out of spite."*
  - Hard Bot: *"Counts your money better than you do. Shows no mercy and even less small talk."*
- Game history is paginated (10/page), reusing the exact same list component My Games/Home/Account already share -- "potentially all their games," not a short teaser.
- Back returns to wherever the profile was opened from (Leaderboard, or the game detail modal's context).
- Direct visit/refresh at `/players/<username>` works too.

No backend query changes were needed for the profile stats or game history themselves -- both already worked generically for any known username. The only real backend addition is resolving a bot's shared identity inside `get_game_detail` so its name has something to link to.

## Testing

- Full backend suite: 525 passed (2 new tests: the bot-profile endpoint fields, and the new `bot_profile_username` join).
- Verified live via Playwright (21 checks): leaderboard → human profile with real stats/meta/game history; game-detail-modal names linking correctly for both a human and a bot (bot showing its friendly name + bio, not player-since/last-played); Back returning to Leaderboard; a direct `/players/<username>` visit after login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)