### PR TITLE
Fix profile back-nav bug, add Elo chart to public profiles, style tables

### DIFF
--- a/highsociety/web/static/css/lobby.css
+++ b/highsociety/web/static/css/lobby.css
@@ -1321,15 +1321,42 @@ button.secondary.standalone { margin-top: 0.9rem; display: inline-block; }
 /* Width + centering for .leaderboard-panel itself now live in main.css,
    alongside every other screen's own panel-centering rule. */
 
+/* Shared by both the Leaderboard screen's own table and the game detail
+   modal's ("game results") -- flagged as looking bland/monotone in both
+   places, so one fix here covers both rather than needing two. */
 .leaderboard-table { width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.9rem; }
 .leaderboard-table th, .leaderboard-table td {
   padding: 0.5rem 0.6rem;
   text-align: left;
   border-bottom: 1px solid var(--panel-border);
 }
-.leaderboard-table th { color: var(--muted); font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.03em; }
+.leaderboard-table th {
+  color: var(--muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  /* A slightly heavier bottom border than the body rows below it --
+     separates the header as its own band instead of just looking like
+     one more (uppercase) row in an otherwise perfectly flat table. */
+  border-bottom: 2px solid var(--panel-border);
+}
+/* Alternating row tint -- a real zebra pattern reads as a deliberately
+   designed table, not a wall of identical rows; :not(.leaderboard-row-me)
+   so the "this is you" highlight below always wins on whichever row it
+   lands on, striped or not. */
+.leaderboard-table tbody tr:nth-child(even):not(.leaderboard-row-me) { background: var(--panel-bg-soft); }
 .leaderboard-row-me { background: var(--accent-soft); font-weight: 700; }
 .leaderboard-rank-1 { color: var(--accent-strong); font-weight: 800; font-size: 1.05rem; }
+/* A clickable name inside one of these tables previously only looked
+   different from static text on hover -- from a first glance at the
+   table itself, nothing distinguished it. Colored + a visible (if
+   subtle) underline at rest gives it the same "this is a link" read
+   every other link in the app already has; the existing hover rule in
+   game.css still darkens it further on top of this. */
+.leaderboard-table .name-link {
+  color: var(--accent-strong);
+  text-decoration-color: rgba(143, 106, 34, 0.4);
+}
 .leaderboard-pagination { display: flex; align-items: center; justify-content: center; gap: 1rem; margin-top: 0.9rem; }
 .leaderboard-pagination button { margin: 0; }
 .leaderboard-pagination button:disabled { opacity: 0.4; cursor: default; }

--- a/highsociety/web/static/js/account/account.js
+++ b/highsociety/web/static/js/account/account.js
@@ -11,6 +11,7 @@ import { fetchJSON } from '../lobby/lobby.js';
 // note on its own import from here.
 import { fetchGamesPage, renderIfChanged } from '../lobby/gameHistory.js';
 import { showToast } from '../ui/notifications.js';
+import { createEloChartController } from '../ui/eloChart.js';
 
 // Static catalog mirroring highsociety/code/common/achievements.py's
 // ACHIEVEMENTS -- small enough to duplicate client-side (12 entries) rather
@@ -170,174 +171,16 @@ async function loadAccountStats() {
 
 // ------------------------------------------------------------ Elo chart --
 //
-// Drawn with ApexCharts (MIT-licensed, one of the most widely used JS
-// charting libraries) -- switched from Chart.js specifically for its
-// area-chart look: a real gradient fill under the line, a built-in
-// datetime x-axis (no separate date-adapter package needed, unlike
-// Chart.js's own "time" scale), and a themeable tooltip/crosshair,
-// closer to what a polished rating-history chart is expected to look
-// like out of the box. Vendored locally as a single UMD bundle
-// (highsociety/web/static/js/vendor/apexcharts.min.js) rather than
-// pulled from a CDN or given a build step -- self-registers
-// window.ApexCharts from a classic <script>, loaded lazily (see
-// loadApexCharts below) only the first time this screen actually needs
-// it, so every other screen never pays for it.
-let apexChartsLoadPromise = null;
-
-function loadApexCharts() {
-  if (window.ApexCharts) return Promise.resolve();
-  if (!apexChartsLoadPromise) {
-    apexChartsLoadPromise = new Promise((resolve, reject) => {
-      const script = document.createElement('script');
-      script.src = '/static/js/vendor/apexcharts.min.js';
-      script.onload = resolve;
-      script.onerror = () => { apexChartsLoadPromise = null; reject(new Error('Failed to load apexcharts')); };
-      document.head.appendChild(script);
-    });
-  }
-  return apexChartsLoadPromise;
-}
-
-// A CSS custom property's raw value (e.g. "#1f7a4d") -- ApexCharts draws
-// on inline SVG, which has no idea what a CSS variable is either, so
-// every color handed to it has to already be a resolved literal.
-function cssVar(name) {
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-}
-
-let eloChart = null; // the live ApexCharts instance, if any -- see renderEloChart
-let fullEloHistory = []; // the unfiltered fetch, so the 7D/30D/All toggle can re-slice without a new request -- see loadEloChart/onEloChartRangeClick
-
-// Client-side only -- get_rating_history already returns everything, so
-// narrowing to a window is just a filter on timestamps already in hand,
-// never a re-fetch.
-function filterHistoryByRange(history, range) {
-  if (range === 'all') return history;
-  const days = range === '7' ? 7 : 30;
-  const cutoffMs = Date.now() - days * 24 * 60 * 60 * 1000;
-  return history.filter((h) => new Date(h.created_at).getTime() >= cutoffMs);
-}
-
-export function onEloChartRangeClick(e) {
-  const btn = e.target.closest('.account-elo-chart-range-btn');
-  if (!btn) return;
-  document.querySelectorAll('#account-elo-chart-range-toggle .account-elo-chart-range-btn').forEach((b) => {
-    b.classList.toggle('selected', b === btn);
-  });
-  renderEloChart(filterHistoryByRange(fullEloHistory, btn.dataset.range));
-}
-
-// `history`: [{old_rating, new_rating, created_at}, ...] oldest first (see
-// get_rating_history), already narrowed to whatever range is currently
-// selected (see filterHistoryByRange) -- an empty array here means "no
-// games in this window", which shows a small inline message rather than
-// hiding the whole tile (the range toggle above it should stay reachable
-// so a different window can still be picked). Plots every new_rating,
-// prefixed by the very first entry's old_rating so the line actually
-// starts somewhere instead of jumping in mid-air on its first point.
-//
-// A real datetime x-axis (each point keeps its actual timestamp) rather
-// than evenly-spaced-by-index -- an index-based layout would spread a
-// burst of several games played in one evening across the *entire*
-// width, identical to if they'd been spread across months, which is what
-// made the old sparkline look like a meaningless zigzag rather than an
-// actual rating history. The prefixed old_rating point sits at a
-// synthetic time just before the first real game (5% of the whole span
-// back) purely so the line has a visible starting slope -- it's never a
-// real game's own timestamp.
-async function renderEloChart(history) {
-  const container = $('account-elo-chart');
-  if (eloChart) { eloChart.destroy(); eloChart = null; }
-  container.classList.remove('loading');
-  if (history.length === 0) {
-    container.innerHTML = '<p class="muted account-elo-chart-empty">No games in this range.</p>';
-    return;
-  }
-  container.innerHTML = '';
-  try {
-    await loadApexCharts();
-  } catch (e) {
-    // ApexCharts genuinely failed to load (offline, ad-blocker, ...) --
-    // unlike the empty-range case above, there's no chart at all to show
-    // regardless of range, so this hides the whole tile, range toggle
-    // included.
-    hide($('account-elo-chart-section'));
-    return;
-  }
-
-  const gameTimes = history.map((h) => new Date(h.created_at).getTime());
-  const span = gameTimes[gameTimes.length - 1] - gameTimes[0] || 1;
-  const times = [gameTimes[0] - span * 0.05, ...gameTimes];
-  const values = [history[0].old_rating, ...history.map((h) => h.new_rating)];
-  const trendUp = values[values.length - 1] >= values[0];
-  const lineColor = trendUp ? cssVar('--chip-money') : cssVar('--danger');
-  const gridColor = cssVar('--panel-border');
-  const textColor = cssVar('--muted');
-
-  eloChart = new window.ApexCharts(container, {
-    chart: {
-      type: 'area',
-      // A numeric pixel height, not '100%' -- ApexCharts resolves a
-      // percentage height against the parent at mount time, and that
-      // measurement came out taller than the container's own 200px
-      // (275px, observed), which the container (no overflow:hidden)
-      // doesn't clip -- the extra height visibly spilled out of the
-      // tile and over whatever sat below it. A concrete number matching
-      // the CSS height in lobby.css always lands exactly on-target.
-      height: 200,
-      fontFamily: 'inherit',
-      background: 'transparent',
-      toolbar: { show: false },
-      zoom: { enabled: false },
-      animations: { speed: 400 },
-    },
-    // A legend is pure clutter for a single named series -- it also ate
-    // into the height budget above, part of why the chart rendered
-    // taller than intended.
-    legend: { show: false },
-    series: [{ name: 'Rating', data: times.map((t, i) => [t, values[i]]) }],
-    colors: [lineColor],
-    stroke: { curve: 'smooth', width: 2.5 },
-    // The gradient fill under the line is the single biggest visual
-    // upgrade a real area chart brings over a bare line. Fading all the
-    // way to fully transparent (opacityTo: 0) read as only partially
-    // shaded -- the lower portion of the area looked empty. Without an
-    // explicit gradientToColors, ApexCharts fades the bottom stop to
-    // white rather than to the series' own color, which against this
-    // app's light cream panel background read as no fill at all -- so
-    // this pins both gradient stops to the same lineColor and only
-    // varies the opacity, keeping a visible tinted floor the whole way
-    // down instead of washing out to white.
-    fill: {
-      type: 'gradient',
-      gradient: { shadeIntensity: 1, gradientToColors: [lineColor], opacityFrom: 0.4, opacityTo: 0.12, stops: [0, 100] },
-    },
-    markers: { size: 0, hover: { size: 5 } },
-    dataLabels: { enabled: false },
-    grid: {
-      borderColor: gridColor,
-      strokeDashArray: 0,
-      xaxis: { lines: { show: false } },
-      yaxis: { lines: { show: true } },
-      padding: { left: 8, right: 8 },
-    },
-    xaxis: {
-      type: 'datetime',
-      labels: { style: { colors: textColor, fontSize: '11px' }, datetimeUTC: false },
-      axisBorder: { show: false },
-      axisTicks: { show: false },
-    },
-    yaxis: {
-      labels: { style: { colors: textColor, fontSize: '11px' }, formatter: (v) => Math.round(v) },
-    },
-    tooltip: {
-      theme: 'dark',
-      x: { format: 'MMM d, yyyy' },
-      y: { formatter: (v) => `Rating: ${Math.round(v)}` },
-    },
-  });
-  await eloChart.render();
-}
+// The actual ApexCharts implementation lives in ui/eloChart.js now,
+// shared with a public Player Profile's own identical chart (see
+// lobby/playerProfile.js) -- this screen just owns one controller
+// instance pointed at its own ids.
+const eloChartController = createEloChartController({
+  containerId: 'account-elo-chart',
+  sectionId: 'account-elo-chart-section',
+  rangeToggleId: 'account-elo-chart-range-toggle',
+});
+export function onEloChartRangeClick(e) { eloChartController.onRangeClick(e); }
 
 // Guests never accrue real rating history (record_finished_game only
 // rates google_id-linked players -- same gate account-elo's own Unrated
@@ -348,24 +191,8 @@ async function renderEloChart(history) {
 // even starts) -- checked again here only defensively, in case this is
 // ever called from somewhere that skipped that step.
 async function loadEloChart(profile) {
-  const section = $('account-elo-chart-section');
-  if (!profile || !profile.google_id) { hide(section); return; }
-  try {
-    const result = await fetchJSON(`/api/profile/${encodeURIComponent(profile.username)}/rating_history`);
-    fullEloHistory = result.history || [];
-    if (fullEloHistory.length === 0) { hide(section); return; }
-    // A fresh load (a different profile, or just re-opening this screen)
-    // always starts from "All" -- a 7D/30D selection left over from a
-    // previous visit silently carrying over would show a narrower window
-    // than the toggle itself appears to say, with nothing indicating why.
-    document.querySelectorAll('#account-elo-chart-range-toggle .account-elo-chart-range-btn').forEach((b) => {
-      b.classList.toggle('selected', b.dataset.range === 'all');
-    });
-    show(section);
-    await renderEloChart(fullEloHistory);
-  } catch (e) {
-    hide(section);
-  }
+  if (!profile || !profile.google_id) { hide($('account-elo-chart-section')); return; }
+  await eloChartController.load(`/api/profile/${encodeURIComponent(profile.username)}/rating_history`);
 }
 
 // -------------------------------------------------------- recent activity --

--- a/highsociety/web/static/js/app.js
+++ b/highsociety/web/static/js/app.js
@@ -32,6 +32,7 @@ import {
 } from './lobby/leaderboard.js';
 import {
   getPlayerProfileReturnTo, onPlayerProfileHistoryPrevClick, onPlayerProfileHistoryNextClick,
+  onPlayerProfileEloChartRangeClick,
 } from './lobby/playerProfile.js';
 import { onPlayClick, onFindMatch, onMatchmakingCancel, onMatchmakingAddBots } from './lobby/matchmaking.js';
 import {
@@ -144,6 +145,7 @@ function wireStaticHandlers() {
   $('btn-home-recent-games-see-more').addEventListener('click', () => navigateFromSidebar(() => showGameHistoryScreen('home')));
   $('btn-account-recent-activity-see-more').addEventListener('click', () => navigateFromSidebar(() => showGameHistoryScreen('account')));
   $('account-elo-chart-range-toggle').addEventListener('click', onEloChartRangeClick);
+  $('player-profile-elo-chart-range-toggle').addEventListener('click', onPlayerProfileEloChartRangeClick);
   $('btn-game-history-prev').addEventListener('click', onGameHistoryPrevClick);
   $('btn-game-history-next').addEventListener('click', onGameHistoryNextClick);
   $('sidebar-leaderboard').addEventListener('click', () => navigateFromSidebar(showLeaderboardScreen));
@@ -151,13 +153,25 @@ function wireStaticHandlers() {
   $('btn-leaderboard-next').addEventListener('click', onLeaderboardNextClick);
   $('leaderboard-body').addEventListener('click', onLeaderboardTableClick);
   $('game-detail-body').addEventListener('click', onGameDetailTableClick);
-  // Reached from a name click (Leaderboard or the game detail modal), not
-  // the sidebar -- Back returns to whichever one was actually used
-  // (getPlayerProfileReturnTo, same "returnTo" idea as Game History's own
-  // multi-entry-point Back button above).
+  // Reached from a name click (Leaderboard, or the game detail modal
+  // opened from Home/My Games/Account/another profile) -- Back has to
+  // return to whichever *specific* screen actually opened it, not just
+  // Leaderboard, which was a real reported bug: opening a game from
+  // Home's own widget and clicking a name in it landed on Leaderboard
+  // instead of back on Home. getPlayerProfileReturnTo() is either the
+  // literal string 'leaderboard' or a real screen id captured at the
+  // moment the game detail modal opened (see ui/modals.js's
+  // openGameDetailModal) -- this is the one place that turns a screen id
+  // back into "how do I actually re-show that screen", since it already
+  // owns every one of those re-show functions.
   $('btn-player-profile-back').addEventListener('click', () => navigateFromSidebar(() => {
-    if (getPlayerProfileReturnTo() === 'leaderboard') showLeaderboardScreen();
-    else { showScreen('screen-host-setup'); showHomeTiles(); startRoomsPolling(); }
+    const returnTo = getPlayerProfileReturnTo();
+    if (returnTo === 'leaderboard') { showLeaderboardScreen(); return; }
+    if (returnTo === 'screen-game-history') { showGameHistoryScreen(getGameHistoryReturnTo()); return; }
+    if (returnTo === 'screen-account') { showAccountScreen(); return; }
+    // 'screen-host-setup' (Home) and anything unrecognized both land on
+    // the tile picker -- Home has no extra state of its own to restore.
+    showScreen('screen-host-setup'); showHomeTiles(); startRoomsPolling();
   }));
   $('btn-player-profile-history-prev').addEventListener('click', onPlayerProfileHistoryPrevClick);
   $('btn-player-profile-history-next').addEventListener('click', onPlayerProfileHistoryNextClick);

--- a/highsociety/web/static/js/lobby/playerProfile.js
+++ b/highsociety/web/static/js/lobby/playerProfile.js
@@ -9,6 +9,17 @@ import { $, hide, show, showScreen, setScreenPath } from '../utils/dom.js';
 import { timeAgo } from '../utils/formatting.js';
 import { fetchJSON } from './lobby.js';
 import { fetchGamesPage, renderIfChanged } from './gameHistory.js';
+import { createEloChartController } from '../ui/eloChart.js';
+
+// Same shared chart Account's own screen uses (see ui/eloChart.js), a
+// separate controller instance so this screen's chart state (fetched
+// history, live chart object) is never confused with Account's own.
+const eloChartController = createEloChartController({
+  containerId: 'player-profile-elo-chart',
+  sectionId: 'player-profile-elo-chart-section',
+  rangeToggleId: 'player-profile-elo-chart-range-toggle',
+});
+export function onPlayerProfileEloChartRangeClick(e) { eloChartController.onRangeClick(e); }
 
 const PAGE_SIZE = 10; // matches gameHistory.js's own fixed page size -- fetchGamesPage bakes this in already
 
@@ -16,10 +27,16 @@ const dateLabel = (iso) => new Date(iso).toLocaleDateString('en-US', { month: 's
 
 let profileUsername = null; // the profile currently shown/loading -- stale-response guard for both loaders below
 let profileOffset = 0;
-// Where the Back button returns to -- this screen has two real entry
-// points (Leaderboard, the game detail modal opened from anywhere), same
-// "returnTo" idea gameHistory.js already established for its own Back
-// button's identical multi-entry-point problem.
+// Where the Back button returns to -- either the literal string
+// 'leaderboard' (clicked a name directly on the Leaderboard), or the id
+// of whichever screen was actually showing underneath when the game
+// detail modal that led here was opened (see ui/modals.js's
+// openGameDetailModal, which captures that id the instant it opens --
+// Home, My Games, and Account can all open that same modal, and each
+// needs its own real screen back, not always Leaderboard, which was a
+// real reported bug: opening a game from Home and clicking a name in it
+// landed back on Leaderboard, not Home). app.js's Back handler is what
+// actually turns a screen id back into "how do I re-show that screen".
 let profileReturnTo = 'leaderboard';
 
 export function getPlayerProfileReturnTo() {
@@ -39,11 +56,20 @@ export function showPlayerProfileScreen(username, returnTo = 'leaderboard') {
   hide($('player-profile-meta-row'));
   hide($('player-profile-elo-hero'));
   $('player-profile-stats-row').classList.add('loading');
+  hide($('player-profile-elo-chart-section'));
+  $('player-profile-elo-chart').classList.add('loading');
   hide($('player-profile-history-section'));
   $('player-profile-history-list').innerHTML = '';
   delete $('player-profile-history-list').dataset.renderedHtml; // a stale renderIfChanged memo from a *different* profile must never suppress this one's first real paint
 
+  // All three run independently -- none awaits or blocks another, same as
+  // Account's own screen-open already does. The chart's own relevance
+  // guard matters here in a way Account never had to worry about:
+  // clicking from one player's profile straight to another's (far more
+  // plausible than a login/logout cycle) could otherwise paint a slow
+  // first fetch's stale data into a screen that's since moved on.
   loadPlayerProfileStats(username);
+  eloChartController.load(`/api/profile/${encodeURIComponent(username)}/rating_history`, () => username === profileUsername);
   loadPlayerProfileHistoryPage();
 }
 

--- a/highsociety/web/static/js/ui/eloChart.js
+++ b/highsociety/web/static/js/ui/eloChart.js
@@ -1,0 +1,219 @@
+// Shared ApexCharts-based Elo history chart -- originally Account-only
+// (see git history), pulled out here so a public Player Profile can show
+// the exact same chart for the profile it's viewing, not a second
+// bespoke implementation. A factory (one call per screen instance)
+// rather than bare module-level state: Account and a Player Profile need
+// entirely independent state (their own fetched history / live chart
+// instance), and even within one screen, navigating from one profile to
+// another needs a clean slate, not state left over from whoever was
+// viewed before.
+import { $, hide, show } from '../utils/dom.js';
+import { fetchJSON } from '../lobby/lobby.js';
+
+// Real axes/gridlines/tooltips via a real charting library, vendored
+// locally as a single UMD bundle (highsociety/web/static/js/vendor/
+// apexcharts.min.js) rather than pulled from a CDN or given a build
+// step -- self-registers window.ApexCharts from a classic <script>,
+// loaded lazily only the first time any screen actually needs it, so
+// every other screen never pays for it. One shared load promise across
+// every controller instance -- the library itself is a single global
+// script tag, not something each screen needs its own copy of.
+let apexChartsLoadPromise = null;
+function loadApexCharts() {
+  if (window.ApexCharts) return Promise.resolve();
+  if (!apexChartsLoadPromise) {
+    apexChartsLoadPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = '/static/js/vendor/apexcharts.min.js';
+      script.onload = resolve;
+      script.onerror = () => { apexChartsLoadPromise = null; reject(new Error('Failed to load apexcharts')); };
+      document.head.appendChild(script);
+    });
+  }
+  return apexChartsLoadPromise;
+}
+
+// A CSS custom property's raw value (e.g. "#1f7a4d") -- ApexCharts draws
+// on inline SVG, which has no idea what a CSS variable is either, so
+// every color handed to it has to already be a resolved literal.
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+// Client-side only -- get_rating_history already returns everything, so
+// narrowing to a window is just a filter on timestamps already in hand,
+// never a re-fetch.
+function filterHistoryByRange(history, range) {
+  if (range === 'all') return history;
+  const days = range === '7' ? 7 : 30;
+  const cutoffMs = Date.now() - days * 24 * 60 * 60 * 1000;
+  return history.filter((h) => new Date(h.created_at).getTime() >= cutoffMs);
+}
+
+// `containerId`/`sectionId`/`rangeToggleId`: the 3 elements every caller
+// of this chart already has (see index.html's Account and Player Profile
+// markup, identical structure, different ids) -- a heading with a
+// .section-icon, the range-toggle button row, and the chart's own div.
+export function createEloChartController({ containerId, sectionId, rangeToggleId }) {
+  let chart = null; // the live ApexCharts instance, if any
+  let fullHistory = []; // the unfiltered fetch, so the 7D/30D/All toggle can re-slice without a new request
+
+  // `history`: [{old_rating, new_rating, created_at}, ...] oldest first
+  // (see get_rating_history), already narrowed to whatever range is
+  // currently selected (see filterHistoryByRange) -- an empty array here
+  // means "no games in this window", which shows a small inline message
+  // rather than hiding the whole tile (the range toggle above it should
+  // stay reachable so a different window can still be picked). Plots
+  // every new_rating, prefixed by the very first entry's old_rating so
+  // the line actually starts somewhere instead of jumping in mid-air on
+  // its first point.
+  //
+  // A real datetime x-axis (each point keeps its actual timestamp)
+  // rather than evenly-spaced-by-index -- an index-based layout would
+  // spread a burst of several games played in one evening across the
+  // *entire* width, identical to if they'd been spread across months,
+  // which is what made the old sparkline look like a meaningless zigzag
+  // rather than an actual rating history. The prefixed old_rating point
+  // sits at a synthetic time just before the first real game (5% of the
+  // whole span back) purely so the line has a visible starting slope --
+  // it's never a real game's own timestamp.
+  async function render(history) {
+    const container = $(containerId);
+    if (chart) { chart.destroy(); chart = null; }
+    container.classList.remove('loading');
+    if (history.length === 0) {
+      container.innerHTML = '<p class="muted account-elo-chart-empty">No games in this range.</p>';
+      return;
+    }
+    container.innerHTML = '';
+    try {
+      await loadApexCharts();
+    } catch (e) {
+      // ApexCharts genuinely failed to load (offline, ad-blocker, ...) --
+      // unlike the empty-range case above, there's no chart at all to
+      // show regardless of range, so this hides the whole tile, range
+      // toggle included.
+      hide($(sectionId));
+      return;
+    }
+
+    const gameTimes = history.map((h) => new Date(h.created_at).getTime());
+    const span = gameTimes[gameTimes.length - 1] - gameTimes[0] || 1;
+    const times = [gameTimes[0] - span * 0.05, ...gameTimes];
+    const values = [history[0].old_rating, ...history.map((h) => h.new_rating)];
+    const trendUp = values[values.length - 1] >= values[0];
+    const lineColor = trendUp ? cssVar('--chip-money') : cssVar('--danger');
+    const gridColor = cssVar('--panel-border');
+    const textColor = cssVar('--muted');
+
+    chart = new window.ApexCharts(container, {
+      chart: {
+        type: 'area',
+        // A numeric pixel height, not '100%' -- ApexCharts resolves a
+        // percentage height against the parent at mount time, and that
+        // measurement came out taller than the container's own 200px
+        // (275px, observed), which the container (no overflow:hidden)
+        // doesn't clip -- the extra height visibly spilled out of the
+        // tile and over whatever sat below it. A concrete number
+        // matching the CSS height in lobby.css always lands exactly
+        // on-target.
+        height: 200,
+        fontFamily: 'inherit',
+        background: 'transparent',
+        toolbar: { show: false },
+        zoom: { enabled: false },
+        animations: { speed: 400 },
+      },
+      // A legend is pure clutter for a single named series -- it also
+      // ate into the height budget above, part of why the chart used to
+      // render taller than intended.
+      legend: { show: false },
+      series: [{ name: 'Rating', data: times.map((t, i) => [t, values[i]]) }],
+      colors: [lineColor],
+      stroke: { curve: 'smooth', width: 2.5 },
+      // The gradient fill under the line is the single biggest visual
+      // upgrade a real area chart brings over a bare line. Fading all
+      // the way to fully transparent (opacityTo: 0) read as only
+      // partially shaded -- the lower portion of the area looked empty.
+      // Without an explicit gradientToColors, ApexCharts fades the
+      // bottom stop to white rather than to the series' own color, which
+      // against this app's light cream panel background read as no fill
+      // at all -- so this pins both gradient stops to the same lineColor
+      // and only varies the opacity, keeping a visible tinted floor the
+      // whole way down instead of washing out to white.
+      fill: {
+        type: 'gradient',
+        gradient: { shadeIntensity: 1, gradientToColors: [lineColor], opacityFrom: 0.4, opacityTo: 0.12, stops: [0, 100] },
+      },
+      markers: { size: 0, hover: { size: 5 } },
+      dataLabels: { enabled: false },
+      grid: {
+        borderColor: gridColor,
+        strokeDashArray: 0,
+        xaxis: { lines: { show: false } },
+        yaxis: { lines: { show: true } },
+        padding: { left: 8, right: 8 },
+      },
+      xaxis: {
+        type: 'datetime',
+        labels: { style: { colors: textColor, fontSize: '11px' }, datetimeUTC: false },
+        axisBorder: { show: false },
+        axisTicks: { show: false },
+      },
+      yaxis: {
+        labels: { style: { colors: textColor, fontSize: '11px' }, formatter: (v) => Math.round(v) },
+      },
+      tooltip: {
+        theme: 'dark',
+        x: { format: 'MMM d, yyyy' },
+        y: { formatter: (v) => `Rating: ${Math.round(v)}` },
+      },
+    });
+    await chart.render();
+  }
+
+  function onRangeClick(e) {
+    const btn = e.target.closest('.account-elo-chart-range-btn');
+    if (!btn) return;
+    document.querySelectorAll(`#${rangeToggleId} .account-elo-chart-range-btn`).forEach((b) => {
+      b.classList.toggle('selected', b === btn);
+    });
+    render(filterHistoryByRange(fullHistory, btn.dataset.range));
+  }
+
+  // Fetches `historyUrl` (the caller's own /api/profile/<username>/rating_history)
+  // and renders it -- hides the whole section if there's genuinely
+  // nothing to plot (no rated games yet) rather than showing an empty
+  // chart. Callers decide for themselves whether it's worth calling at
+  // all (Account gates on profile.google_id; a Player Profile just
+  // always tries, since bots are real rated participants too now).
+  //
+  // `isStillRelevant`, if given, is checked right before touching the DOM
+  // -- a Player Profile can navigate from one player to another before
+  // this resolves (unlike Account, there's no login/logout gate slowing
+  // that down), and without this a slow first fetch could paint stale
+  // data into a screen that's since moved on to someone else entirely.
+  async function load(historyUrl, isStillRelevant = () => true) {
+    const section = $(sectionId);
+    try {
+      const result = await fetchJSON(historyUrl);
+      if (!isStillRelevant()) return;
+      fullHistory = result.history || [];
+      if (fullHistory.length === 0) { hide(section); return; }
+      // A fresh load (a different profile, or just re-opening this
+      // screen) always starts from "All" -- a 7D/30D selection left over
+      // from a previous visit silently carrying over would show a
+      // narrower window than the toggle itself appears to say, with
+      // nothing indicating why.
+      document.querySelectorAll(`#${rangeToggleId} .account-elo-chart-range-btn`).forEach((b) => {
+        b.classList.toggle('selected', b.dataset.range === 'all');
+      });
+      show(section);
+      await render(fullHistory);
+    } catch (e) {
+      if (isStillRelevant()) hide(section);
+    }
+  }
+
+  return { load, onRangeClick };
+}

--- a/highsociety/web/static/js/ui/modals.js
+++ b/highsociety/web/static/js/ui/modals.js
@@ -61,11 +61,20 @@ export async function openProfileModal(username) {
 }
 export function closeProfileModal() { hide($('profile-view-modal')); }
 
-// "Click a game -> see full results" -- the same modal serves both the
-// My Games screen and the home page's Recent Games widget (see
-// lobby/gameHistory.js, which only ever fetches the list; this owns the
-// one detail view both lists open into).
+// "Click a game -> see full results" -- the same modal serves the Home
+// widget, My Games, Account's Recent Activity, and a Player Profile's own
+// game history (see lobby/gameHistory.js, which only ever fetches the
+// list; this owns the one detail view every caller opens into).
 export async function openGameDetailModal(gameId) {
+  // Captured the instant the modal opens (before anything else changes)
+  // -- this is a real screen id (e.g. 'screen-host-setup' for Home,
+  // 'screen-game-history' for My Games, 'screen-account'), since the
+  // modal is only ever an overlay on top of whatever's already showing.
+  // Used by onGameDetailTableClick below so a name clicked inside this
+  // modal returns Back to wherever the modal was actually opened from --
+  // a real reported bug otherwise: it always assumed Leaderboard,
+  // landing there even when the modal was opened from Home.
+  gameDetailOpenerScreenId = document.querySelector('.screen:not(.hidden)')?.id || null;
   const body = $('game-detail-body');
   body.innerHTML = '';
   $('game-detail-date').textContent = '';
@@ -99,15 +108,27 @@ export async function openGameDetailModal(gameId) {
 }
 export function closeGameDetailModal() { hide($('game-detail-modal')); }
 
+let gameDetailOpenerScreenId = null; // see openGameDetailModal's own comment
+
 // Wired from index.html's game-detail-body click delegation (see app.js,
 // same data-attribute-click-delegation pattern rematch.js's own
 // onStandingsTableClick already uses for its own name links). Closing
 // the modal first, then navigating, matches what closing it always did
 // anyway -- this just also happens to land somewhere instead of nowhere.
+// The opener screen id is passed straight through as returnTo -- app.js's
+// Back handler is what turns a screen id into "how do I re-show that
+// screen" (it already owns every one of those re-show functions).
+// Falls back to 'leaderboard' for the one case that's genuinely ambiguous
+// (this same modal opened from *another* Player Profile's own game
+// history -- chasing that arbitrarily deep would need a real navigation
+// stack, not worth it for how rarely that specific path comes up).
 export function onGameDetailTableClick(e) {
   const btn = e.target.closest('[data-username]');
   if (btn) {
+    const returnTo = (gameDetailOpenerScreenId && gameDetailOpenerScreenId !== 'screen-player-profile')
+      ? gameDetailOpenerScreenId
+      : 'leaderboard';
     closeGameDetailModal();
-    showPlayerProfileScreen(btn.dataset.username, 'leaderboard');
+    showPlayerProfileScreen(btn.dataset.username, returnTo);
   }
 }

--- a/highsociety/web/templates/index.html
+++ b/highsociety/web/templates/index.html
@@ -568,6 +568,30 @@
           </div>
         </div>
 
+        <!-- Elo history -- same shared ui/eloChart.js controller Account's
+             own chart uses (see playerProfile.js), not a second bespoke
+             implementation. Hidden for anyone with no rated games at all
+             (a guest, or a bot with no known difficulty) -- see
+             loadPlayerProfileEloChart's own guard. Shown for bots too:
+             they're real rated participants now, and their Elo trend is
+             genuine, not a placeholder. -->
+        <div id="player-profile-elo-chart-section" class="card panel account-panel hidden">
+          <h3>
+            <span class="section-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M3.5 18.5l5.5-6 4 3.5 6.5-8"/><path d="M15.5 7.5h4.5V12"/>
+              </svg>
+            </span>
+            Elo progress
+          </h3>
+          <div id="player-profile-elo-chart-range-toggle" class="account-elo-chart-range-toggle">
+            <button type="button" class="account-elo-chart-range-btn" data-range="7">7D</button>
+            <button type="button" class="account-elo-chart-range-btn" data-range="30">30D</button>
+            <button type="button" class="account-elo-chart-range-btn selected" data-range="all">All</button>
+          </div>
+          <div id="player-profile-elo-chart" class="account-elo-chart loading"></div>
+        </div>
+
         <div id="player-profile-history-section" class="card panel account-panel hidden">
           <h3>
             <span class="section-icon" aria-hidden="true">


### PR DESCRIPTION
## Summary

Addresses items from BACKEND_REWORK.MD / FRONTEND_REWORK.MD:

**BACKEND_REWORK.MD #1** (real bug): Home -> Recent Games -> click a game -> click a player -> Back landed on Leaderboard instead of Home. Fixed by capturing which real screen was showing underneath the game detail modal the instant it opens (Home/My Games/Account/another Player Profile), and using that as the Back target.

**BACKEND_REWORK.MD #2** ("why no Elo plot on public profiles?"): not a bug -- an initial scope cut. Closed it: extracted the ApexCharts implementation out of `account.js` into a shared `ui/eloChart.js`, so both Account and any public Player Profile draw from one implementation. Shown for bots too (they're real rated participants). Added a relevance guard so quickly clicking from one profile to another can't paint stale chart data into the wrong screen.

**FRONTEND_REWORK.MD #1 + #2** (bland/monotone tables, name-links not reading as clickable): both the Leaderboard table and the game detail modal's table share one CSS class already -- added alternating row tint and made clickable names colored+underlined at rest (previously only visible on hover).

BACKEND_REWORK.MD #3 ("why is a public profile slower than my own?") was answered directly in conversation rather than as a code change -- Account gets a login-time prefetch head start a public profile structurally can't have; per explicit instruction, the hover-prefetch mitigation discussed for it was **not** implemented here.

## Testing

- Full backend suite: 526 passed (frontend-only change, unaffected).
- Verified live via Playwright (13 checks): back-nav fix confirmed from Home's own widget; a bot with no backing identity renders as plain text, not a dead link; a bot's public profile shows a real, working Elo chart with its own range toggle; both tables show visible striping and colored name-links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)