### PR TITLE
Fix Account/Player Profile tiles starting lower than every other screen

### DIFF
--- a/highsociety/web/static/css/lobby.css
+++ b/highsociety/web/static/css/lobby.css
@@ -639,14 +639,6 @@ h3:has(.section-icon) { display: flex; align-items: center; gap: 0.5rem; }
   margin: 0;
 }
 .home-back:hover, .screen-back:hover { color: var(--accent-strong); }
-/* Account's own back button sits directly on the dark felt background
-   (outside any panel, see .account-screen-wrap in index.html) unlike
-   every other .screen-back usage, which stays the first element *inside*
-   its own light-colored .panel -- the shared muted/brown color those all
-   use read as nearly invisible against dark felt. Same light tone the
-   sidebar/topbar already use on this same background. */
-.account-screen-wrap > .screen-back { color: rgba(245, 241, 230, 0.78); }
-.account-screen-wrap > .screen-back:hover { color: #f5f1e6; }
 
 /* ---------------- host form ---------------- */
 

--- a/highsociety/web/static/css/main.css
+++ b/highsociety/web/static/css/main.css
@@ -527,7 +527,13 @@ input.needs-attention {
    than one long panel, which the 460px width every plain form uses would
    leave cramped regardless. The wrapper (not each individual .panel)
    owns the centering/max-width now, since there are multiple sibling
-   panels to keep aligned as one column instead of just one. */
+   panels to keep aligned as one column instead of just one.
+   The Back button lives inside the *first* tile (same as every other
+   screen's own .panel), not as a wrapper-level sibling above it -- it
+   used to sit outside, which left an extra flex item + gap above the
+   actual visible tile, starting it visibly lower than every other
+   screen's first tile even though this wrapper's own margin-top matched
+   them exactly. A real reported misalignment, not a hypothetical one. */
 .account-screen-wrap {
   max-width: 680px;
   margin: var(--screen-top-gap) auto;
@@ -535,7 +541,6 @@ input.needs-attention {
   flex-direction: column;
   gap: 1.1rem;
 }
-.account-screen-wrap > .screen-back { align-self: flex-start; }
 .account-screen-wrap .account-panel { box-shadow: var(--shadow); margin-bottom: 0; }
 
 

--- a/highsociety/web/templates/index.html
+++ b/highsociety/web/templates/index.html
@@ -229,9 +229,8 @@
            .hidden class, same as before) -- this only changes how they're
            grouped/spaced when shown, not when each one appears. -->
       <div class="account-screen-wrap">
-        <button type="button" class="screen-back" id="btn-account-back">← Back</button>
-
         <div class="card panel account-panel">
+          <button type="button" class="screen-back" id="btn-account-back">← Back</button>
           <div class="account-header">
           <span id="account-avatar" class="profile-chip-avatar account-avatar"></span>
           <div>
@@ -474,9 +473,8 @@
          *anyone*, with no edit affordances at all. -->
     <section id="screen-player-profile" class="screen hidden">
       <div class="account-screen-wrap">
-        <button type="button" class="screen-back" id="btn-player-profile-back">← Back</button>
-
         <div class="card panel account-panel">
+          <button type="button" class="screen-back" id="btn-player-profile-back">← Back</button>
           <div class="account-header">
             <span id="player-profile-avatar" class="profile-chip-avatar account-avatar"></span>
             <div>


### PR DESCRIPTION
## Summary

Reported: tiles on Account/Player Profile start visibly lower than Home/Leaderboard/My Games's own tiles, despite all of them sharing the same `--screen-top-gap` top margin.

Root cause: on these two screens, the Back button sat *outside* the first tile as its own flex item inside `.account-screen-wrap` (with the wrapper's own `gap` on top of that) -- every other screen's Back button lives *inside* its own `.panel`. The wrapper's margin-top matched every other screen exactly, but the actual visible tile underneath it didn't, landing about 48px lower.

Fix: moved the Back button back inside the first tile, matching every other screen's own structure, and removed the CSS that only existed because it used to sit directly on the dark felt background outside any panel (a contrast override + an `align-self` rule, both now dead).

## Testing

- Verified via Playwright: Account's and Player Profile's first tile now sit at the exact same top position as Home's tile and Leaderboard's panel (within 2px, down from a ~48px gap).
- Full backend suite: 526 passed (frontend-only change; one unrelated flaky WebSocket test confirmed passing in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)