### PR TITLE
Make How to Play visual and interactive

### DIFF
--- a/highsociety/web/static/css/lobby.css
+++ b/highsociety/web/static/css/lobby.css
@@ -648,6 +648,150 @@ h3:has(.section-icon) { display: flex; align-items: center; gap: 0.5rem; }
 .account-screen-wrap > .screen-back { color: rgba(245, 241, 230, 0.78); }
 .account-screen-wrap > .screen-back:hover { color: #f5f1e6; }
 
+/* ---------------- how to play (rich, dedicated-screen version) ---------------- */
+/* See _how_to_play_rich.html -- real card art (reusing the exact
+   .status-card/.green-dot the live game itself renders, not new
+   illustrations), side-by-side auction-type comparison cards, small
+   "remember this" callouts, and a scripted (canned data, no backend)
+   auction walkthrough. Wider than the 460px every plain form-style Home
+   panel uses (#screen-host-setup .panel) -- a 2-column comparison and a
+   5-tile card gallery both read as cramped at that width. */
+#screen-host-setup .home-panel-rules { max-width: 720px; }
+
+.rules-section-heading { margin-top: 1.6rem; }
+
+/* A small highlighted callout restating one specific gotcha -- distinct
+   from a plain <p class="hint"> (which is just quieter body text): a
+   left accent bar + tinted background reads as "pause and remember
+   this" the way a real margin note or cue card would. */
+.rules-cue-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.7rem;
+  background: var(--accent-soft);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  padding: 0.8rem 1rem;
+  margin: 1rem 0;
+}
+.rules-cue-card p { margin: 0; }
+.rules-cue-card-icon {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-strong);
+}
+.rules-cue-card-icon svg { width: 20px; height: 20px; }
+/* The "4 green cards ends the game" callout gets the actual green-card
+   color instead of the default gold accent -- ties the callout visually
+   to the exact card color it's talking about. */
+.rules-cue-card-icon-green { color: var(--card-green-2); }
+.rules-cue-card-flip { background: rgba(31, 122, 77, 0.1); border-left-color: var(--chip-money); }
+.rules-cue-card-flip .rules-cue-card-icon { color: var(--chip-money); }
+
+.rules-auction-compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.9rem;
+  margin: 0.9rem 0;
+}
+@media (max-width: 560px) { .rules-auction-compare { grid-template-columns: 1fr; } }
+.rules-auction-card {
+  background: var(--panel-bg-soft);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-sm);
+  padding: 1rem;
+}
+.rules-auction-card h4 { margin: 0.6rem 0 0.1rem; font-size: 1rem; }
+.rules-auction-card p { margin: 0.4rem 0 0; font-size: 0.88rem; }
+.rules-auction-card .hint { margin: 0; }
+.rules-auction-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.rules-auction-icon svg { width: 19px; height: 19px; }
+.rules-auction-icon-normal { background: var(--accent-soft); color: var(--accent-strong); }
+/* The disgrace card gets its own gently-tinted variant of the standard
+   card colors (not the actual --danger red -- a disgrace auction isn't
+   an error state, just a different, opposite-incentive rule) so the two
+   cards read as a genuine pair rather than one being an afterthought. */
+.rules-auction-card-disgrace { background: rgba(163, 48, 42, 0.06); border-color: rgba(163, 48, 42, 0.25); }
+.rules-auction-icon-disgrace { background: var(--danger-soft); color: var(--danger); }
+
+.rules-card-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1rem;
+  margin: 0.9rem 0;
+}
+.rules-card-tile { text-align: center; }
+.rules-card-tile p { margin: 0.5rem 0 0; font-size: 0.82rem; color: var(--muted); }
+.rules-card-tile strong { color: var(--text); }
+/* .status-card is already sized/colored by game.css (same face the live
+   game itself renders) -- these two overrides only add what a lone
+   demo/gallery tile specifically needs on top of that. */
+.rules-card-tile .status-card { position: relative; }
+.rules-card-tile .status-card .green-dot { top: 6px; right: 6px; }
+
+/* ---------------- how to play: scripted auction demo ---------------- */
+/* See rulesDemo.js -- entirely canned/fixed data, no backend or real
+   game state involved, just a step-through illustration of how a bid
+   sequence actually plays out for each of the two auction types. */
+.rules-demo-toggle { display: flex; gap: 0.5rem; margin: 0.9rem 0; }
+.rules-demo-box {
+  background: var(--panel-bg-soft);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-sm);
+  padding: 1.1rem;
+}
+.rules-demo-seats { display: flex; justify-content: space-around; gap: 0.6rem; flex-wrap: wrap; margin-bottom: 1rem; }
+.rules-demo-seat {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.9rem;
+  text-align: center;
+  min-width: 92px;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+/* The seat currently acting (bidding/passing this step) -- a gold ring,
+   same "this is the highlighted one" language the live game's own
+   active-turn indicator uses. */
+.rules-demo-seat.active { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
+/* The seat that ends up holding the card once the auction resolves --
+   green, distinct from "currently acting" gold, since by the final step
+   nobody is "acting" any more. */
+.rules-demo-seat.winner { border-color: var(--chip-money); box-shadow: 0 0 0 2px rgba(31, 122, 77, 0.18); }
+.rules-demo-seat-name { font-weight: 700; font-size: 0.85rem; }
+.rules-demo-seat-money { font-size: 0.85rem; color: var(--chip-money); font-weight: 600; margin-top: 0.15rem; }
+.rules-demo-seat-bid {
+  display: inline-block;
+  margin-top: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #fff;
+  background: var(--accent);
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+}
+.rules-demo-seat-passed { display: inline-block; margin-top: 0.35rem; font-size: 0.75rem; color: var(--muted); font-style: italic; }
+.rules-demo-card-area { display: flex; justify-content: center; margin-bottom: 1rem; }
+.rules-demo-narration {
+  text-align: center;
+  min-height: 2.6em;
+  font-size: 0.92rem;
+  margin: 0 0 1rem;
+}
+.rules-demo-controls { display: flex; align-items: center; justify-content: center; gap: 1rem; }
+.rules-demo-controls button { margin: 0; }
+
 /* ---------------- host form ---------------- */
 
 .host-header {

--- a/highsociety/web/static/css/lobby.css
+++ b/highsociety/web/static/css/lobby.css
@@ -724,6 +724,10 @@ h3:has(.section-icon) { display: flex; align-items: center; gap: 0.5rem; }
    cards read as a genuine pair rather than one being an afterthought. */
 .rules-auction-card-disgrace { background: rgba(163, 48, 42, 0.06); border-color: rgba(163, 48, 42, 0.25); }
 .rules-auction-icon-disgrace { background: var(--danger-soft); color: var(--danger); }
+/* Same icon markup as Normal auction's own, flipped -- see that icon's
+   own HTML comment for why this is a mirror rather than a second
+   hand-drawn glyph. */
+.rules-auction-icon-disgrace svg { transform: scaleY(-1); }
 
 .rules-card-gallery {
   display: grid;

--- a/highsociety/web/static/css/lobby.css
+++ b/highsociety/web/static/css/lobby.css
@@ -774,7 +774,6 @@ h3:has(.section-icon) { display: flex; align-items: center; gap: 0.5rem; }
    nobody is "acting" any more. */
 .rules-demo-seat.winner { border-color: var(--chip-money); box-shadow: 0 0 0 2px rgba(31, 122, 77, 0.18); }
 .rules-demo-seat-name { font-weight: 700; font-size: 0.85rem; }
-.rules-demo-seat-money { font-size: 0.85rem; color: var(--chip-money); font-weight: 600; margin-top: 0.15rem; }
 .rules-demo-seat-bid {
   display: inline-block;
   margin-top: 0.35rem;

--- a/highsociety/web/static/js/app.js
+++ b/highsociety/web/static/js/app.js
@@ -35,6 +35,7 @@ import {
   onPlayerProfileEloChartRangeClick,
 } from './lobby/playerProfile.js';
 import { onPlayClick, onFindMatch, onMatchmakingCancel, onMatchmakingAddBots } from './lobby/matchmaking.js';
+import { showRulesDemo, onRulesDemoToggleClick, onRulesDemoPrevClick, onRulesDemoNextClick } from './lobby/rulesDemo.js';
 import {
   onRequestRematchClick, onCancelRematchForm, onSendRematchRequest, onAcceptRematch, onDeclineRematch,
   onStandingsTableClick,
@@ -90,6 +91,13 @@ function wireStaticHandlers() {
     btn.addEventListener('click', onBotStepperClick);
   });
   initHostBotSteppers();
+  // Scripted How to Play demo -- purely static/canned content (see
+  // rulesDemo.js), so it's safe to render once at boot rather than only
+  // when the Rules panel is actually opened.
+  $('rules-demo-toggle').addEventListener('click', onRulesDemoToggleClick);
+  $('btn-rules-demo-prev').addEventListener('click', onRulesDemoPrevClick);
+  $('btn-rules-demo-next').addEventListener('click', onRulesDemoNextClick);
+  showRulesDemo('normal');
   $('btn-join-by-code').addEventListener('click', onJoinByCode);
   $('join-room-code').addEventListener('input', onJoinRoomCodeInput);
   $('join-room-code').addEventListener('keydown', (e) => { if (e.key === 'Enter' && !$('btn-join-by-code').disabled) onJoinByCode(e); });

--- a/highsociety/web/static/js/lobby/rulesDemo.js
+++ b/highsociety/web/static/js/lobby/rulesDemo.js
@@ -2,17 +2,20 @@
 // (normal vs. disgrace) on the dedicated How to Play screen -- see
 // _how_to_play_rich.html. Entirely canned/fixed data: no backend call,
 // no real game state, just a fixed sequence of {seats, card, narration}
-// snapshots stepped through with Next/Prev. Simplified money (round
-// numbers, one running total per seat) rather than the real game's
-// discrete cash-denomination system -- the point here is teaching the
-// bid/pass/win *mechanic*, not replicating the exact cash mechanics the
-// rest of this page already explains in words.
+// snapshots stepped through with Next/Prev.
+//
+// Deliberately no running money total per seat -- an earlier version
+// showed one starting at a flat 100, which read as a real game mechanic
+// (a lump-sum counter) when the actual game has no such thing: money is
+// a fixed hand of specific cash-value cards (see HSConfig's
+// starting_cash_values), never a single number that ticks up or down.
+// The bid *amounts* named in the narration below are real and worth
+// keeping; a per-seat running total was the misleading, invented part.
 import { $ } from '../utils/dom.js';
 
 const SEAT_NAMES = ['You', 'Marble bot', 'Ziggy bot'];
-const START_MONEY = 100;
 
-// Each step: `card` ({label, kind}) and `seats` (money/bid/passed/active/
+// Each step: `card` ({label, kind}) and `seats` (bid/passed/active/
 // winner per seat, indices matching SEAT_NAMES) describe the state to
 // render *at* that step; `narration` is what's happening as it's reached.
 const DEMOS = {
@@ -22,39 +25,27 @@ const DEMOS = {
     steps: [
       {
         narration: 'A Painting worth 7 points is up for auction.',
-        seats: [
-          { money: START_MONEY }, { money: START_MONEY }, { money: START_MONEY },
-        ],
+        seats: [{}, {}, {}],
       },
       {
         narration: 'You open the bidding at 3.',
-        seats: [
-          { money: START_MONEY, bid: 3, active: true }, { money: START_MONEY }, { money: START_MONEY },
-        ],
+        seats: [{ bid: 3, active: true }, {}, {}],
       },
       {
         narration: 'Marble bot raises to 5.',
-        seats: [
-          { money: START_MONEY, bid: 3 }, { money: START_MONEY, bid: 5, active: true }, { money: START_MONEY },
-        ],
+        seats: [{ bid: 3 }, { bid: 5, active: true }, {}],
       },
       {
         narration: "You pass -- you're out, and nothing was ever actually taken from you.",
-        seats: [
-          { money: START_MONEY, passed: true }, { money: START_MONEY, bid: 5 }, { money: START_MONEY },
-        ],
+        seats: [{ passed: true }, { bid: 5 }, {}],
       },
       {
         narration: 'Ziggy bot raises to 8. Nobody else raises again.',
-        seats: [
-          { money: START_MONEY, passed: true }, { money: START_MONEY, bid: 5 }, { money: START_MONEY, bid: 8, active: true },
-        ],
+        seats: [{ passed: true }, { bid: 5 }, { bid: 8, active: true }],
       },
       {
-        narration: 'Ziggy bot wins the Painting for 8 -- pays 8, everyone else keeps every chip they never actually spent.',
-        seats: [
-          { money: START_MONEY, passed: true }, { money: START_MONEY }, { money: START_MONEY - 8, winner: true },
-        ],
+        narration: 'Ziggy bot wins the Painting, paying 8 -- everyone else keeps every chip they never actually spent.',
+        seats: [{ passed: true }, {}, { winner: true }],
       },
     ],
   },
@@ -64,33 +55,23 @@ const DEMOS = {
     steps: [
       {
         narration: "Faux Pas is up -- a disgrace auction. Remember: the FIRST to pass gets stuck with it.",
-        seats: [
-          { money: START_MONEY }, { money: START_MONEY }, { money: START_MONEY },
-        ],
+        seats: [{}, {}, {}],
       },
       {
         narration: 'You raise to 2, hoping someone else passes first.',
-        seats: [
-          { money: START_MONEY, bid: 2, active: true }, { money: START_MONEY }, { money: START_MONEY },
-        ],
+        seats: [{ bid: 2, active: true }, {}, {}],
       },
       {
         narration: 'Marble bot raises to 4 -- same idea, trying to outlast you.',
-        seats: [
-          { money: START_MONEY, bid: 2 }, { money: START_MONEY, bid: 4, active: true }, { money: START_MONEY },
-        ],
+        seats: [{ bid: 2 }, { bid: 4, active: true }, {}],
       },
       {
         narration: 'Ziggy bot passes first -- stuck with Faux Pas, but keeps every chip.',
-        seats: [
-          { money: START_MONEY, bid: 2 }, { money: START_MONEY, bid: 4 }, { money: START_MONEY, passed: true, winner: true },
-        ],
+        seats: [{ bid: 2 }, { bid: 4 }, { passed: true, winner: true }],
       },
       {
         narration: 'You and Marble bot get your raised money back -- you never actually spent it. Ziggy bot must now discard a Painting.',
-        seats: [
-          { money: START_MONEY }, { money: START_MONEY }, { money: START_MONEY, winner: true },
-        ],
+        seats: [{}, {}, { winner: true }],
       },
     ],
   },

--- a/highsociety/web/static/js/lobby/rulesDemo.js
+++ b/highsociety/web/static/js/lobby/rulesDemo.js
@@ -96,7 +96,6 @@ function renderStep() {
     return `
       <div class="${classes}">
         <div class="rules-demo-seat-name">${SEAT_NAMES[i]}</div>
-        <div class="rules-demo-seat-money">${s.money}</div>
         ${badge}
       </div>
     `;

--- a/highsociety/web/static/js/lobby/rulesDemo.js
+++ b/highsociety/web/static/js/lobby/rulesDemo.js
@@ -1,0 +1,152 @@
+// A scripted, step-through illustration of one auction of each type
+// (normal vs. disgrace) on the dedicated How to Play screen -- see
+// _how_to_play_rich.html. Entirely canned/fixed data: no backend call,
+// no real game state, just a fixed sequence of {seats, card, narration}
+// snapshots stepped through with Next/Prev. Simplified money (round
+// numbers, one running total per seat) rather than the real game's
+// discrete cash-denomination system -- the point here is teaching the
+// bid/pass/win *mechanic*, not replicating the exact cash mechanics the
+// rest of this page already explains in words.
+import { $ } from '../utils/dom.js';
+
+const SEAT_NAMES = ['You', 'Marble bot', 'Ziggy bot'];
+const START_MONEY = 100;
+
+// Each step: `card` ({label, kind}) and `seats` (money/bid/passed/active/
+// winner per seat, indices matching SEAT_NAMES) describe the state to
+// render *at* that step; `narration` is what's happening as it's reached.
+const DEMOS = {
+  normal: {
+    cardLabel: '7',
+    cardKind: 'neutral', // matches .status-card's own modifier classes
+    steps: [
+      {
+        narration: 'A Painting worth 7 points is up for auction.',
+        seats: [
+          { money: START_MONEY }, { money: START_MONEY }, { money: START_MONEY },
+        ],
+      },
+      {
+        narration: 'You open the bidding at 3.',
+        seats: [
+          { money: START_MONEY, bid: 3, active: true }, { money: START_MONEY }, { money: START_MONEY },
+        ],
+      },
+      {
+        narration: 'Marble bot raises to 5.',
+        seats: [
+          { money: START_MONEY, bid: 3 }, { money: START_MONEY, bid: 5, active: true }, { money: START_MONEY },
+        ],
+      },
+      {
+        narration: "You pass -- you're out, and nothing was ever actually taken from you.",
+        seats: [
+          { money: START_MONEY, passed: true }, { money: START_MONEY, bid: 5 }, { money: START_MONEY },
+        ],
+      },
+      {
+        narration: 'Ziggy bot raises to 8. Nobody else raises again.',
+        seats: [
+          { money: START_MONEY, passed: true }, { money: START_MONEY, bid: 5 }, { money: START_MONEY, bid: 8, active: true },
+        ],
+      },
+      {
+        narration: 'Ziggy bot wins the Painting for 8 -- pays 8, everyone else keeps every chip they never actually spent.',
+        seats: [
+          { money: START_MONEY, passed: true }, { money: START_MONEY }, { money: START_MONEY - 8, winner: true },
+        ],
+      },
+    ],
+  },
+  disgrace: {
+    cardLabel: '🚫',
+    cardKind: '', // the plain dark default .status-card face, same as Faux Pas' own gallery tile above
+    steps: [
+      {
+        narration: "Faux Pas is up -- a disgrace auction. Remember: the FIRST to pass gets stuck with it.",
+        seats: [
+          { money: START_MONEY }, { money: START_MONEY }, { money: START_MONEY },
+        ],
+      },
+      {
+        narration: 'You raise to 2, hoping someone else passes first.',
+        seats: [
+          { money: START_MONEY, bid: 2, active: true }, { money: START_MONEY }, { money: START_MONEY },
+        ],
+      },
+      {
+        narration: 'Marble bot raises to 4 -- same idea, trying to outlast you.',
+        seats: [
+          { money: START_MONEY, bid: 2 }, { money: START_MONEY, bid: 4, active: true }, { money: START_MONEY },
+        ],
+      },
+      {
+        narration: 'Ziggy bot passes first -- stuck with Faux Pas, but keeps every chip.',
+        seats: [
+          { money: START_MONEY, bid: 2 }, { money: START_MONEY, bid: 4 }, { money: START_MONEY, passed: true, winner: true },
+        ],
+      },
+      {
+        narration: 'You and Marble bot get your raised money back -- you never actually spent it. Ziggy bot must now discard a Painting.',
+        seats: [
+          { money: START_MONEY }, { money: START_MONEY }, { money: START_MONEY, winner: true },
+        ],
+      },
+    ],
+  },
+};
+
+let currentDemo = 'normal';
+let currentStep = 0;
+
+function renderStep() {
+  const demo = DEMOS[currentDemo];
+  const step = demo.steps[currentStep];
+
+  const card = $('rules-demo-card');
+  card.textContent = demo.cardLabel;
+  card.className = `status-card big ${demo.cardKind}`.trim();
+
+  $('rules-demo-seats').innerHTML = step.seats.map((s, i) => {
+    const classes = ['rules-demo-seat', s.active && 'active', s.winner && 'winner'].filter(Boolean).join(' ');
+    const badge = s.passed
+      ? '<span class="rules-demo-seat-passed">Passed</span>'
+      : (s.bid != null ? `<span class="rules-demo-seat-bid">Bid ${s.bid}</span>` : '');
+    return `
+      <div class="${classes}">
+        <div class="rules-demo-seat-name">${SEAT_NAMES[i]}</div>
+        <div class="rules-demo-seat-money">${s.money}</div>
+        ${badge}
+      </div>
+    `;
+  }).join('');
+
+  $('rules-demo-narration').textContent = step.narration;
+  $('rules-demo-step-label').textContent = `${currentStep + 1} / ${demo.steps.length}`;
+  $('btn-rules-demo-prev').disabled = currentStep === 0;
+  const isLastStep = currentStep === demo.steps.length - 1;
+  $('btn-rules-demo-next').textContent = isLastStep ? 'Restart ↺' : 'Next →';
+}
+
+export function showRulesDemo(type) {
+  currentDemo = type;
+  currentStep = 0;
+  renderStep();
+}
+
+export function onRulesDemoToggleClick(e) {
+  const btn = e.target.closest('[data-demo]');
+  if (!btn) return;
+  document.querySelectorAll('#rules-demo-toggle [data-demo]').forEach((b) => b.classList.toggle('selected', b === btn));
+  showRulesDemo(btn.dataset.demo);
+}
+
+export function onRulesDemoPrevClick() {
+  if (currentStep > 0) { currentStep -= 1; renderStep(); }
+}
+
+export function onRulesDemoNextClick() {
+  const demo = DEMOS[currentDemo];
+  if (currentStep < demo.steps.length - 1) { currentStep += 1; } else { currentStep = 0; } // "Restart ↺" on the last step, per renderStep's own label swap
+  renderStep();
+}

--- a/highsociety/web/templates/_how_to_play_rich.html
+++ b/highsociety/web/templates/_how_to_play_rich.html
@@ -44,10 +44,18 @@
     <p>Players take turns raising the bid. Passing means you're out. The last one standing wins the card <strong>and pays their bid</strong>.</p>
   </div>
   <div class="rules-auction-card rules-auction-card-disgrace">
+    <!-- The exact same rising-bars-and-arrow icon as Normal auction,
+         mirrored (see .rules-auction-icon-disgrace's own CSS) rather than
+         a second hand-drawn glyph -- a custom "reversed" icon here
+         previously rendered small enough to look like an unrelated
+         script character instead of a clear icon. Flipping the one
+         icon that already reads cleanly guarantees this one does too,
+         and "same shape, upside down" is exactly what "opposite result"
+         means here. -->
     <span class="rules-auction-icon rules-auction-icon-disgrace" aria-hidden="true">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M4 4h16"/><path d="M7 4v8"/><path d="M12 4v13"/><path d="M17 4v8"/>
-        <path d="M17 20l3-3-3-3"/>
+        <path d="M4 20h16"/><path d="M7 20V12"/><path d="M12 20V7"/><path d="M17 20v-9"/>
+        <path d="M17 4l3 3-3 3"/>
       </svg>
     </span>
     <h4>Disgrace auction</h4>
@@ -63,7 +71,7 @@
       <path d="M7 21.9l-4-4 4-4"/><path d="M21 11.9v2a4 4 0 0 1-4 4H3"/>
     </svg>
   </span>
-  <p>In a disgrace auction, passing early is <em>winning</em>. Raising the bid is the risky move — it's the one you don't want to win.</p>
+  <p>In a disgrace auction, passing early is <em>winning</em>. Raising the bid risks real money: if anyone else passes before you do, every chip you raised is gone for nothing.</p>
 </div>
 
 <p class="hint">Money committed to a bid is locked in until the auction resolves — you can raise it later, but can't take it back. Anything you don't win with is returned to you.</p>

--- a/highsociety/web/templates/_how_to_play_rich.html
+++ b/highsociety/web/templates/_how_to_play_rich.html
@@ -1,0 +1,124 @@
+<!-- The rich, visual How to Play content -- dedicated-screen only (see
+     index.html's own comment on #home-panel-rules): the Join screen's
+     collapsed summary keeps using the plain _how_to_play_body.html
+     partial instead, since cramming card art and a scripted demo into a
+     tiny <details> mid-flow would be more clutter than help there. -->
+
+<div class="htp-jump-links">
+  <a href="#htp2-goal">Goal</a>
+  <a href="#htp2-auctions">Auctions</a>
+  <a href="#htp2-cards">Cards</a>
+  <a href="#htp2-demo">Try it</a>
+</div>
+
+<p id="htp2-goal">
+  <strong>Goal:</strong> End the game with the most points — but there's a catch.
+  When the game ends, whoever has the <strong>least money left</strong> is eliminated
+  from winning entirely. If two or more players are tied for the least money, none of
+  them are eliminated — everyone stays in contention. Only then, among whoever remains,
+  does the highest score win.
+</p>
+
+<div class="rules-cue-card">
+  <span class="rules-cue-card-icon" aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M12 9v4"/><path d="M12 16.5h.01"/>
+      <path d="M10.3 3.9 2.6 17.5a1.8 1.8 0 0 0 1.56 2.7h15.68a1.8 1.8 0 0 0 1.56-2.7L13.7 3.9a1.8 1.8 0 0 0-3.4 0Z"/>
+    </svg>
+  </span>
+  <p>Spending every last chip can lose you the game outright, no matter how many points you're sitting on.</p>
+</div>
+
+<h3 id="htp2-auctions" class="rules-section-heading">Two kinds of auction</h3>
+
+<div class="rules-auction-compare">
+  <div class="rules-auction-card">
+    <span class="rules-auction-icon rules-auction-icon-normal" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M4 20h16"/><path d="M7 20V12"/><path d="M12 20V7"/><path d="M17 20v-9"/>
+        <path d="M17 4l3 3-3 3"/>
+      </svg>
+    </span>
+    <h4>Normal auction</h4>
+    <p class="hint">Paintings, the Prestige Card</p>
+    <p>Players take turns raising the bid. Passing means you're out. The last one standing wins the card <strong>and pays their bid</strong>.</p>
+  </div>
+  <div class="rules-auction-card rules-auction-card-disgrace">
+    <span class="rules-auction-icon rules-auction-icon-disgrace" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M4 4h16"/><path d="M7 4v8"/><path d="M12 4v13"/><path d="M17 4v8"/>
+        <path d="M17 20l3-3-3-3"/>
+      </svg>
+    </span>
+    <h4>Disgrace auction</h4>
+    <p class="hint">Faux Pas, Passe, Scandale</p>
+    <p>Same bidding, opposite result: the <strong>first player to pass</strong> gets stuck with the card and keeps their money. Everyone else forfeits what they raised.</p>
+  </div>
+</div>
+
+<div class="rules-cue-card rules-cue-card-flip">
+  <span class="rules-cue-card-icon" aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M17 2.1l4 4-4 4"/><path d="M3 12.1v-2a4 4 0 0 1 4-4h14"/>
+      <path d="M7 21.9l-4-4 4-4"/><path d="M21 11.9v2a4 4 0 0 1-4 4H3"/>
+    </svg>
+  </span>
+  <p>In a disgrace auction, passing early is <em>winning</em>. Raising the bid is the risky move — it's the one you don't want to win.</p>
+</div>
+
+<p class="hint">Money committed to a bid is locked in until the auction resolves — you can raise it later, but can't take it back. Anything you don't win with is returned to you.</p>
+
+<h3 id="htp2-cards" class="rules-section-heading">The cards</h3>
+
+<div class="rules-card-gallery">
+  <div class="rules-card-tile">
+    <div class="status-card big neutral">1–10</div>
+    <p><strong>Painting</strong><br>10 in the deck, one of each value — worth that many points.</p>
+  </div>
+  <div class="rules-card-tile">
+    <div class="status-card big green">×2<span class="green-dot" title="Green card"></span></div>
+    <p><strong>Prestige Card</strong><br>3 in the deck — doubles your entire final score.</p>
+  </div>
+  <div class="rules-card-tile">
+    <div class="status-card big">🚫</div>
+    <p><strong>Faux Pas</strong><br>1 in the deck — discard a Painting you own (or your next one, if you have none yet).</p>
+  </div>
+  <div class="rules-card-tile">
+    <div class="status-card big">−5</div>
+    <p><strong>Passe</strong><br>1 in the deck — costs 5 points off your final total.</p>
+  </div>
+  <div class="rules-card-tile">
+    <div class="status-card big green">÷2<span class="green-dot" title="Green card"></span></div>
+    <p><strong>Scandale</strong><br>1 in the deck — halves your entire final score.</p>
+  </div>
+</div>
+
+<div class="rules-cue-card">
+  <span class="rules-cue-card-icon rules-cue-card-icon-green" aria-hidden="true">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="8.5"/>
+    </svg>
+  </span>
+  <p>Green cards can end the game early: the instant the 4th green card (Prestige or Scandale) is revealed, the game stops right there — even mid-round.</p>
+</div>
+
+<h3 id="htp2-demo" class="rules-section-heading">Try it: a scripted walkthrough</h3>
+<p class="hint">Not a real game — a fixed, step-by-step example so you can see how each auction actually plays out.</p>
+
+<div class="rules-demo-toggle" id="rules-demo-toggle">
+  <button type="button" class="pill-choice-btn selected" data-demo="normal">Normal auction</button>
+  <button type="button" class="pill-choice-btn" data-demo="disgrace">Disgrace auction</button>
+</div>
+
+<div id="rules-demo-box" class="rules-demo-box">
+  <div class="rules-demo-seats" id="rules-demo-seats"></div>
+  <div class="rules-demo-card-area">
+    <div id="rules-demo-card" class="status-card big"></div>
+  </div>
+  <p id="rules-demo-narration" class="rules-demo-narration"></p>
+  <div class="rules-demo-controls">
+    <button type="button" id="btn-rules-demo-prev" class="secondary" disabled>← Prev</button>
+    <span id="rules-demo-step-label" class="muted"></span>
+    <button type="button" id="btn-rules-demo-next" class="primary">Next →</button>
+  </div>
+</div>

--- a/highsociety/web/templates/_how_to_play_rich.html
+++ b/highsociety/web/templates/_how_to_play_rich.html
@@ -71,7 +71,7 @@
       <path d="M7 21.9l-4-4 4-4"/><path d="M21 11.9v2a4 4 0 0 1-4 4H3"/>
     </svg>
   </span>
-  <p>In a disgrace auction, passing early is <em>winning</em>. Raising the bid risks real money: if anyone else passes before you do, every chip you raised is gone for nothing.</p>
+  <p>In a disgrace auction, passing early is <em>winning</em>. Raising the bid is a trade-off: you risk losing that money for nothing, in exchange for staying out of a card that could become a dealbreaker later on.</p>
 </div>
 
 <p class="hint">Money committed to a bid is locked in until the auction resolves — you can raise it later, but can't take it back. Anything you don't win with is returned to you.</p>

--- a/highsociety/web/templates/index.html
+++ b/highsociety/web/templates/index.html
@@ -809,19 +809,19 @@
         <button id="btn-join-by-code" class="primary" disabled>Join</button>
       </div>
 
-      <div id="home-panel-rules" class="card panel home-panel hidden">
+      <div id="home-panel-rules" class="card panel home-panel home-panel-rules hidden">
         <button type="button" class="home-back">← Back</button>
         <h2>How to play</h2>
+        <!-- The rich, visual version -- real card art, comparison cards
+             for the two auction types, cue-card callouts, and a scripted
+             (fake-data, no backend) auction walkthrough. Deliberately
+             its own separate partial, not a richer variant of
+             _how_to_play_body.html -- that one still renders as-is
+             inside the Join screen's collapsed summary (see below),
+             which stays plain/text on purpose (a quick reminder mid-flow,
+             not where someone goes to actually learn the game). -->
         <div class="how-to-play-body">
-          <!-- htp_jump_links only true for this, the "full page" instance
-               of this shared partial (also included, unlabeled, in the
-               Join screen's own collapsed "how to play" -- see below).
-               Guards both the jump-nav bar and the section ids it targets,
-               since this partial renders twice on the same page and two
-               elements sharing one id would be invalid HTML (and
-               scrollIntoView would only ever find the first one). -->
-          {% set htp_jump_links = true %}
-          {% include "_how_to_play_body.html" %}
+          {% include "_how_to_play_rich.html" %}
         </div>
       </div>
 
@@ -1185,10 +1185,12 @@
         <details class="advanced how-to-play">
           <summary>New to High Society? How to play</summary>
           <div class="how-to-play-body">
-            <!-- Explicitly reset to false -- the flag set above, in
-                 Home's Rules panel, persists for the rest of this
-                 template's render otherwise, which would give this
-                 second copy duplicate ids too. -->
+            <!-- Deliberately the plain partial, not the dedicated Rules
+                 screen's richer _how_to_play_rich.html -- this is a quick
+                 reminder mid-flow, not where someone goes to actually
+                 learn the game, so card art/a scripted demo would just be
+                 clutter here. htp_jump_links off: no jump-nav bar makes
+                 sense inside an already-collapsed <details>. -->
             {% set htp_jump_links = false %}
             {% include "_how_to_play_body.html" %}
           </div>


### PR DESCRIPTION
## Summary

The dedicated How to Play screen was pure text before this. Per discussion: real card art, a visual auction comparison, callout cards, and an optional scripted (not a real game) walkthrough -- scoped to this one screen only, not the Join screen's own collapsed rules summary, which stays plain on purpose.

- **Real card art**: the 5 card types rendered as actual `.status-card` tiles, the exact same face/color the live game itself uses -- not new illustrations.
- **Auction comparison**: Normal vs. Disgrace auctions as two side-by-side cards (icon + a few lines each) instead of a dry definition list.
- **Cue cards**: small highlighted callouts restating the 3 rules easiest to miss (money elimination, the disgrace-auction incentive flip, green cards ending the game early).
- **Scripted demo**: a fixed, step-through auction walkthrough (new `rulesDemo.js`) -- entirely canned data, no backend or real game state -- showing exactly how a normal auction and a disgrace auction each play out, bid by bid, with Next/Prev controls.

The Join screen's collapsed "How to play" summary is untouched -- confirmed via an empty diff on `_how_to_play_body.html`.

## Testing

- Verified via Playwright (10 checks) + screenshots at desktop and 420px mobile: card gallery, auction comparison, and cue cards all render; both demo scripts (normal + disgrace) step through correctly to their resolution.
- Full backend suite: 526 passed (frontend-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)