### PR TITLE
Add a loading spinner to the Elo progress chart

### DIFF
--- a/highsociety/web/static/css/lobby.css
+++ b/highsociety/web/static/css/lobby.css
@@ -311,13 +311,33 @@ h3:has(.section-icon) { display: flex; align-items: center; gap: 0.5rem; }
    observed, even with height:200 and the legend/toolbar both disabled),
    which silently grows the tile 15px past the size actually asked for
    ("too large" was the original complaint) unless overridden here. */
-.account-elo-chart { width: 100%; height: 200px; min-height: 200px !important; overflow: hidden; }
-/* Same pulsing-placeholder language as the stat cards above, so "still
-   loading" reads consistently within this one screen, not just app-wide. */
+.account-elo-chart { width: 100%; height: 200px; min-height: 200px !important; overflow: hidden; position: relative; }
+/* Same pulsing-placeholder language as the stat cards above (so "still
+   loading" reads consistently within this one screen), plus a real
+   spinning ring centered on top -- this tile's own wait is longer and
+   more variable than a plain stat card's (a network fetch *and* a
+   ~500KB charting library the first time it's ever needed), so a flat
+   pulsing block alone read as inert rather than actively working. */
 .account-elo-chart.loading {
   border-radius: var(--radius-sm);
   background: var(--panel-bg-soft);
   animation: stat-skeleton-pulse 1.4s ease-in-out infinite;
+}
+.account-elo-chart.loading::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 28px;
+  height: 28px;
+  margin: -14px 0 0 -14px;
+  border-radius: 50%;
+  border: 3px solid var(--panel-border);
+  border-top-color: var(--accent);
+  animation: rules-spinner-rotate 0.8s linear infinite;
+}
+@keyframes rules-spinner-rotate {
+  to { transform: rotate(360deg); }
 }
 /* "No games in this range" -- shown when a 7D/30D filter narrows the
    real (non-empty) history down to nothing, so the chart area itself

--- a/highsociety/web/static/css/main.css
+++ b/highsociety/web/static/css/main.css
@@ -482,6 +482,10 @@ input.needs-attention {
 }
 @media (prefers-reduced-motion: reduce) {
   .screen:not(.hidden) { animation: none; }
+  /* A continuously-spinning ring is more insistent motion than the
+     screen-settle fade above -- left as a static ring (still reads as
+     "loading"), not hidden outright. */
+  .account-elo-chart.loading::after { animation: none; }
 }
 
 .panel {


### PR DESCRIPTION
The Elo chart's loading state was just a pulsing tint (same skeleton language as the stat cards) -- fine for a quick stat card, but this tile waits on a network fetch *and*, the first time it's ever needed, a ~500KB charting library, so the flat pulse alone read as inert. Added a real spinning ring on top, applies to both Account's own chart and a public Player Profile's (shared controller, one fix covers both). Respects `prefers-reduced-motion`.

Verified via Playwright + screenshots: spinner visible mid-load, gone once the chart renders. Full backend suite green (526 passed, frontend-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)