### PR TITLE
Rework the waiting-room lobby: host-only seat management + a real seat grid

### DIFF
--- a/highsociety/code/gamecore/network/protocol.py
+++ b/highsociety/code/gamecore/network/protocol.py
@@ -31,6 +31,11 @@ PLAYER_MESSAGE_TYPES = {
     "REMATCH_UPDATE",  # a request was just made, or someone just voted on one
     "REMATCH_DECLINED",  # cancels a pending request
     "REMATCH_STARTING",  # unanimous accept — a fresh game is starting now
+    # The host removed this player from a still-open lobby (see
+    # web_server.py's api_remove_seat) -- GLOBAL_EVENT-shaped like the
+    # REMATCH_* trio above, just carrying a human-readable reason in `data`
+    # instead of a rematch payload.
+    "KICKED",
     # A quick emoji (see web_server.py's _relay_player_chat) -- shares
     # CHAT's live, off-thread relay path (WebSocketTransport filters both
     # the same way), but needs its own payload shape (from_user + data,
@@ -110,7 +115,7 @@ def build_player_payload(
             "created_at": created_at,
         }
     elif message_type in ("GLOBAL_EVENT", "AUCTION_RESULT", "AUCTION_UPDATE",
-                          "REMATCH_UPDATE", "REMATCH_DECLINED", "REMATCH_STARTING"):
+                          "REMATCH_UPDATE", "REMATCH_DECLINED", "REMATCH_STARTING", "KICKED"):
         payload = {
             "game_id": game_id,
             "message_type": message_type,

--- a/highsociety/web/static/css/lobby.css
+++ b/highsociety/web/static/css/lobby.css
@@ -1258,6 +1258,134 @@ button.secondary.standalone { margin-top: 0.9rem; display: inline-block; }
   font-size: 0.9rem;
 }
 
+/* ---------------- lobby seat grid ----------------
+   Replaces the old plain-text "Seats filled: 3/5 (Alice, Bob, Marble bot)"
+   line with a real per-seat grid (see JOIN_GAME_REWORK.MD) -- the same
+   live roster data (playerList.js's poll), just rendered as tiles instead
+   of a sentence, with host-only inline controls to add/remove a seat. */
+.lobby-seats-label {
+  margin: 0 0 0.6rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+.lobby-seats {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));
+  gap: 0.6rem;
+  margin-bottom: 1.1rem;
+}
+.lobby-seat {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.7rem 0.4rem 0.6rem;
+  background: var(--panel-bg-soft);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-sm);
+  text-align: center;
+}
+.lobby-seat-avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  font-size: 1rem;
+}
+.lobby-seat-avatar.is-human { border-radius: 50%; }
+.lobby-seat-name {
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+.lobby-seat-name span { display: block; font-weight: 500; color: var(--muted); font-size: 0.7rem; }
+
+/* Hover/focus-reveal remove button -- host-only (see canManageSeats in
+   playerList.js); a non-host viewer's grid never gets the .can-manage
+   class at all, so this never even renders for them. */
+.lobby-seat-remove {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  color: var(--muted);
+  font-size: 0.7rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  transform: scale(0.85);
+  transition: opacity 0.12s ease, transform 0.12s ease, background 0.12s ease, color 0.12s ease;
+}
+.lobby-seat:hover .lobby-seat-remove,
+.lobby-seat-remove:focus-visible {
+  opacity: 1;
+  transform: scale(1);
+}
+.lobby-seat-remove:hover { background: var(--danger); border-color: var(--danger); color: #fff; }
+
+.lobby-seat.open {
+  background: transparent;
+  border: 1.5px dashed var(--panel-border);
+}
+.lobby-seat.open .lobby-seat-name { color: var(--muted); font-weight: 500; }
+.lobby-seat-add-btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  font-size: 1.05rem;
+  background: transparent;
+  border: 1.5px dashed var(--panel-border);
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+}
+.lobby-seat-add-btn:hover, .lobby-seat.open.picker-open .lobby-seat-add-btn {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+/* Add-a-bot popover, anchored under whichever open seat's + was clicked. */
+.lobby-bot-picker {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 132px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 12px 28px -8px rgba(0, 0, 0, 0.35);
+  padding: 0.4rem;
+  z-index: 20;
+  text-align: left;
+}
+.lobby-bot-picker[hidden] { display: none; }
+.lobby-bot-option {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  padding: 0.4rem 0.45rem;
+  font-family: inherit;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+.lobby-bot-option:hover { background: var(--panel-bg-soft); }
+
 .room-code-display {
   display: flex;
   align-items: center;
@@ -1368,6 +1496,22 @@ button.secondary.standalone { margin-top: 0.9rem; display: inline-block; }
   font-size: 0.9rem;
 }
 .room-row button { margin-top: 0; }
+.room-row-main { display: flex; flex-direction: column; gap: 0.35rem; min-width: 0; flex: 1 1 auto; }
+.room-row-code { font-weight: 600; }
+/* A small fill-progress bar reads faster than the bare "(4/5 seats
+   filled)" text it replaces -- see JOIN_GAME_NON_HOST_UI.MD. */
+.room-row-progress { display: flex; align-items: center; gap: 0.5rem; }
+.room-row-bar {
+  flex: 1 1 auto;
+  max-width: 110px;
+  height: 5px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.room-row-bar-fill { height: 100%; background: var(--accent); border-radius: 999px; }
+.room-row-progress-text { font-size: 0.78rem; color: var(--muted); white-space: nowrap; }
 
 /* A dashed, quieter treatment than a real .panel -- this is a "nothing to
    see here (yet)" state, not content of its own, so it shouldn't compete

--- a/highsociety/web/static/js/app.js
+++ b/highsociety/web/static/js/app.js
@@ -23,7 +23,7 @@ import {
   startRoomsPolling, currentRoomCode, isActivelyPlayingLiveGame,
   applySpectateIdentityDefaults, refreshStatus, leaveToHome, setCurrentRoomCode,
 } from './lobby/lobby.js';
-import { onAddBot } from './lobby/playerList.js';
+import { initLobbySeatGrid } from './lobby/playerList.js';
 import {
   showGameHistoryScreen, onGameHistoryPrevClick, onGameHistoryNextClick, getGameHistoryReturnTo,
 } from './lobby/gameHistory.js';
@@ -104,8 +104,8 @@ function wireStaticHandlers() {
   $('btn-copy-room-link').addEventListener('click', onCopyRoomLink);
   $('room-link-input').addEventListener('focus', (e) => e.target.select());
   $('room-link-input').addEventListener('click', (e) => e.target.select());
-  $('btn-add-bot').addEventListener('click', onAddBot);
   $('btn-join').addEventListener('click', onJoin);
+  initLobbySeatGrid();
   $('btn-spectate-link').addEventListener('click', () => {
     applySpectateIdentityDefaults();
     showScreen('screen-spectate-join');

--- a/highsociety/web/static/js/lobby/lobby.js
+++ b/highsociety/web/static/js/lobby/lobby.js
@@ -12,6 +12,7 @@
 // is read inside a function body, never at this module's own top-level
 // evaluation, so load order never matters.
 import { $, hide, show, showError, showScreen, setScreenPath } from '../utils/dom.js';
+import { escapeHtml } from '../utils/formatting.js';
 import { ensureProfileSet, loadProfile, renderProfileChip, saveProfile, setSessionStatus } from '../auth/profile.js';
 import { game, resetGameState, seedOpponents, applyRoomDisplaySettings } from '../game/gameState.js';
 import { renderOpponents } from '../game/gameRenderer.js';
@@ -326,14 +327,21 @@ function renderRoomsList(rooms) {
   rooms.forEach((r) => {
     const row = document.createElement('div');
     row.className = 'room-row';
-    const label = document.createElement('span');
-    label.textContent = `Room ${r.room_code} (${r.joined}/${r.seats} seats filled)`;
+    const fillPct = Math.round((r.joined / r.seats) * 100);
+    const main = document.createElement('div');
+    main.className = 'room-row-main';
+    main.innerHTML = `
+      <span class="room-row-code">Room ${escapeHtml(r.room_code)}</span>
+      <span class="room-row-progress">
+        <span class="room-row-bar"><span class="room-row-bar-fill" style="width: ${fillPct}%"></span></span>
+        <span class="room-row-progress-text">${r.joined}/${r.seats} seats</span>
+      </span>`;
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'secondary';
     btn.textContent = 'Join';
     btn.addEventListener('click', (event) => enterRoom(r.room_code, event));
-    row.appendChild(label);
+    row.appendChild(main);
     row.appendChild(btn);
     container.appendChild(row);
   });
@@ -412,6 +420,8 @@ export function renderForStatus(status) {
     showScreen('screen-join');
     $('join-form').classList.add('hidden');
     $('join-waiting').classList.add('hidden');
+    hide($('lobby-seats-wrap')); // no real seat data worth showing once a game's already running
+    show($('lobby-status'));
     $('lobby-status').textContent = hasResigned
       ? "You resigned from this game. You can watch as a spectator."
       : 'A game is already in progress. You can watch as a spectator.';

--- a/highsociety/web/static/js/lobby/playerList.js
+++ b/highsociety/web/static/js/lobby/playerList.js
@@ -1,24 +1,108 @@
-// The waiting-room roster (before a game starts) and "add a bot" control.
+// The waiting-room roster (before a game starts) -- a real per-seat grid
+// (see JOIN_GAME_REWORK.MD), replacing the old plain-text "Seats filled:
+// 3/5 (Alice, Bob, Marble bot 🤖)" line. Host-only inline controls here
+// add a bot to an open seat or remove any seat (bot or human) -- see
+// canManageSeats and web_server.py's _is_room_host for the exact same
+// "no known host means open to anyone" fallback on both sides.
 //
 // Circular with network/messages.js (which imports startWaitingRoomPolling
-// from here) -- safe, same reasoning as lobby.js's own note: everything
-// here is read inside a function body, never at module-evaluation time.
+// from here) and ui/modals.js (confirmDialog, which itself imports from
+// lobby.js, which imports renderLobby from here) -- safe, same reasoning
+// as lobby.js's own note: everything here is read inside a function body,
+// never at this module's own top-level evaluation.
 import { $, hide, show, showError, showScreen } from '../utils/dom.js';
 import { fetchJSON, currentRoomCode, applyJoinIdentityDefaults } from './lobby.js';
 import { takePendingIdentifyError } from '../network/messages.js';
+import { loadProfile } from '../auth/profile.js';
+import { confirmDialog } from '../ui/modals.js';
+import { escapeHtml } from '../utils/formatting.js';
+
+const BOT_TIERS = [
+  { type: 'easy', label: 'Easy' },
+  { type: 'medium', label: 'Medium' },
+  { type: 'hard', label: 'Hard' },
+];
+
+// Which open seat's "add a bot" popover is showing, by seat index, or
+// null -- purely local UI state, deliberately NOT part of the rendered-html
+// diff below, so a poll tick that doesn't actually change the roster
+// leaves an open popover alone instead of yanking it shut every 1.5s.
+let openPickerSeatIndex = null;
+// The last status this screen rendered -- lets a local-only UI change
+// (opening/closing the bot picker) redraw immediately without waiting for
+// the next poll tick.
+let lastStatus = null;
+
+function canManageSeats(status) {
+  // No known host (an older client, or a matchmaking room -- see
+  // GameRoom.host_username's own comment) means seat management stays
+  // open to anyone, exactly matching web_server.py's _is_room_host.
+  if (!status.host_username) return true;
+  const profile = loadProfile();
+  return !!profile && profile.username === status.host_username;
+}
+
+function seatTileHtml(seat, index, canManage) {
+  if (!seat) {
+    if (!canManage) {
+      return '<div class="lobby-seat open"><div class="lobby-seat-name">Open</div></div>';
+    }
+    const pickerOpen = openPickerSeatIndex === index;
+    const options = BOT_TIERS.map(
+      (t) => `<button type="button" class="lobby-bot-option" data-action="add-bot" data-seat-index="${index}" data-bot-type="${t.type}">${t.label}</button>`
+    ).join('');
+    return `
+      <div class="lobby-seat open${pickerOpen ? ' picker-open' : ''}">
+        <button type="button" class="lobby-seat-add-btn" aria-label="Add a bot" data-action="toggle-picker" data-seat-index="${index}">+</button>
+        <div class="lobby-seat-name">Open</div>
+        <div class="lobby-bot-picker"${pickerOpen ? '' : ' hidden'}>${options}</div>
+      </div>`;
+  }
+  const safeName = escapeHtml(seat.name);
+  const avatarContent = seat.is_bot ? '🤖' : escapeHtml(seat.name.charAt(0).toUpperCase());
+  const nameHtml = seat.is_bot ? `${safeName}<span>Bot</span>` : safeName;
+  const removeBtn = canManage
+    ? `<button type="button" class="lobby-seat-remove" aria-label="Remove ${safeName}" data-action="remove-seat" data-username="${escapeHtml(seat.username)}" data-is-bot="${seat.is_bot}" data-name="${safeName}">×</button>`
+    : '';
+  return `
+    <div class="lobby-seat">
+      ${removeBtn}
+      <div class="lobby-seat-avatar${seat.is_bot ? '' : ' is-human'}">${avatarContent}</div>
+      <div class="lobby-seat-name">${nameHtml}</div>
+    </div>`;
+}
+
+function renderSeatsGrid(status) {
+  lastStatus = status;
+  hide($('lobby-status'));
+  show($('lobby-seats-wrap'));
+  $('lobby-seats-label').textContent = `Seats filled: ${status.joined.length}/${status.seats}`;
+  const canManage = canManageSeats(status);
+  const seats = Array.from({ length: status.seats }, (_, i) => status.joined[i] || null);
+  const html = seats.map((seat, i) => seatTileHtml(seat, i, canManage)).join('');
+  const container = $('lobby-seats');
+  if (container.dataset.renderedHtml === html) return; // no real change -- leave any open popover alone
+  container.innerHTML = html;
+  container.dataset.renderedHtml = html;
+}
 
 export function renderLobby(status) {
   showScreen('screen-join');
   $('join-form').classList.remove('hidden');
   $('join-waiting').classList.add('hidden');
+  hide($('lobby-seats-error')); // a stale error from a previous room must never bleed into this one
+  // A fresh entry point (not the ongoing poll) -- reset local seat-grid UI
+  // state so a previous room's open bot-picker or diff cache can never
+  // bleed into this one.
+  openPickerSeatIndex = null;
+  $('lobby-seats').dataset.renderedHtml = '';
   applyJoinIdentityDefaults();
   const visibilityNote = status.visibility === 'private' ? ' (private, share this code with friends)' : ' (public)';
   $('room-code-text').textContent = `Room code: ${status.room_code}${visibilityNote}`;
   show($('room-code-display'));
   $('room-link-input').value = `${location.origin}${location.pathname}?room=${encodeURIComponent(status.room_code)}`;
   show($('room-link-row'));
-  const names = status.joined.map((p) => `${p.name}${p.is_bot ? ' 🤖' : ''}`).join(', ') || 'nobody yet';
-  $('lobby-status').textContent = `Seats filled: ${status.joined.length}/${status.seats} (${names})`;
+  renderSeatsGrid(status);
   const err = takePendingIdentifyError();
   if (err) showError($('join-error'), err);
 }
@@ -27,10 +111,9 @@ export function renderLobby(status) {
 // connect — see lobby.js's connectPlayerSocket) because "waiting in the
 // lobby after joining" is a distinct phase: nothing about the shared game/
 // opponents state has started yet, but you still want to see the seat
-// count update live as other people join, and to know when there's still
-// an empty seat worth filling with a bot (see onAddBot). Self-cancels once
-// the room leaves "lobby" (game started), so it never runs for the rest of
-// the game.
+// grid update live as other people join/leave/get added/removed. Self-
+// cancels once the room leaves "lobby" (game started), so it never runs
+// for the rest of the game.
 let waitingRoomPollTimer = null;
 
 async function _tickWaitingRoomStatus() {
@@ -44,16 +127,15 @@ async function _tickWaitingRoomStatus() {
     stopWaitingRoomPolling();
     return;
   }
-  const names = status.joined.map((p) => `${p.name}${p.is_bot ? ' 🤖' : ''}`).join(', ') || 'nobody yet';
-  $('lobby-status').textContent = `Seats filled: ${status.joined.length}/${status.seats} (${names})`;
+  renderSeatsGrid(status);
 }
 
 export function startWaitingRoomPolling() {
   if (waitingRoomPollTimer) return;
   // Without this immediate call, setInterval's first tick is 1.5s out --
-  // "Seats filled: 0/3 — nobody yet" (whatever lobby-status showed before
-  // you joined) sits directly next to "You're in!" for that whole window,
-  // visibly contradicting it. Matches lobby.js's startRoomsPolling same fix.
+  // the seat grid would still show whatever it showed before you joined
+  // sitting directly next to "You're in!" for that whole window, visibly
+  // contradicting it. Matches lobby.js's startRoomsPolling same fix.
   _tickWaitingRoomStatus();
   waitingRoomPollTimer = setInterval(_tickWaitingRoomStatus, 1500);
 }
@@ -61,20 +143,105 @@ export function stopWaitingRoomPolling() {
   if (waitingRoomPollTimer) { clearInterval(waitingRoomPollTimer); waitingRoomPollTimer = null; }
 }
 
-export async function onAddBot() {
-  hide($('add-bot-error'));
-  const botType = $('waiting-bot-type').value;
+function seatGridError(message) {
+  showError($('lobby-seats-error'), message);
+}
+
+async function addBot(botType) {
+  openPickerSeatIndex = null;
+  hide($('lobby-seats-error'));
   try {
-    await fetchJSON('/api/add_bot', {
+    const status = await fetchJSON('/api/add_bot', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ room: currentRoomCode(), bot_type: botType }),
+      body: JSON.stringify({
+        room: currentRoomCode(),
+        bot_type: botType,
+        requester_username: loadProfile() ? loadProfile().username : null,
+      }),
     });
-    // The waiting-room poll (already running — see startWaitingRoomPolling)
-    // picks up the new seat count on its own next tick; if this bot filled
-    // the last seat, the game itself starts server-side and this player's
-    // already-open WebSocket starts receiving real game messages naturally.
+    // Paint the response's own fresh status immediately -- an action *you*
+    // just took reflecting back up to 1.5s later (the next waiting-room
+    // poll tick) reads as sluggish/broken in a way that someone *else's*
+    // join, which has no faster signal available, doesn't. If this filled
+    // the last seat the game itself starts server-side and this player's
+    // already-open WebSocket takes over from here; nothing left for the
+    // (self-cancelling) lobby grid to render either way.
+    if (status.state === 'lobby') renderSeatsGrid(status);
   } catch (e) {
-    showError($('add-bot-error'), e.message);
+    seatGridError(e.message);
   }
+}
+
+async function removeSeat(username, isBot, name) {
+  if (!isBot) {
+    const confirmed = await confirmDialog(
+      `This removes ${name} from the game right away. They'll be notified and sent back to the home screen.`,
+      'Remove player'
+    );
+    if (!confirmed) return;
+  }
+  hide($('lobby-seats-error'));
+  try {
+    const status = await fetchJSON('/api/remove_seat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        room: currentRoomCode(),
+        username,
+        requester_username: loadProfile() ? loadProfile().username : null,
+      }),
+    });
+    // Same immediate-paint reasoning as addBot above; a kicked human also
+    // gets their own KICKED message over their own connection (see
+    // network/messages.js), independent of this render.
+    if (status.state === 'lobby') renderSeatsGrid(status);
+  } catch (e) {
+    seatGridError(e.message);
+  }
+}
+
+// Single delegated listener, wired once at boot (see app.js) -- the grid's
+// own innerHTML is fully replaced on every real change (renderSeatsGrid),
+// so binding to individual buttons after each render would mean rebinding
+// constantly; delegating to the never-replaced container avoids that.
+export function initLobbySeatGrid() {
+  const container = $('lobby-seats');
+  container.addEventListener('click', (e) => {
+    const target = e.target.closest('[data-action]');
+    if (!target) return;
+    // Never let this bubble to the document-level click-away listener
+    // below -- relying on it to correctly no-op via e.target.closest on a
+    // node that renderSeatsGridForced may have just detached (toggling the
+    // picker replaces this container's whole innerHTML synchronously,
+    // before bubbling reaches document) is fragile; just stop it here.
+    e.stopPropagation();
+    const action = target.dataset.action;
+    if (action === 'toggle-picker') {
+      const index = Number(target.dataset.seatIndex);
+      openPickerSeatIndex = openPickerSeatIndex === index ? null : index;
+      if (lastStatus) renderSeatsGridForced(lastStatus);
+    } else if (action === 'add-bot') {
+      addBot(target.dataset.botType);
+    } else if (action === 'remove-seat') {
+      removeSeat(target.dataset.username, target.dataset.isBot === 'true', target.dataset.name);
+    }
+  });
+  // Clicking anywhere outside an open seat's own picker closes it --
+  // same pattern as the card-info-popover elsewhere in this app.
+  document.addEventListener('click', (e) => {
+    if (openPickerSeatIndex === null) return;
+    if (e.target.closest('.lobby-seat.open')) return;
+    openPickerSeatIndex = null;
+    if (lastStatus) renderSeatsGridForced(lastStatus);
+  });
+}
+
+// renderSeatsGrid skips its own re-render when the html signature hasn't
+// changed (see its own comment) -- exactly what a purely-local toggle like
+// opening/closing the bot picker needs to bypass, since the roster itself
+// hasn't changed at all.
+function renderSeatsGridForced(status) {
+  $('lobby-seats').dataset.renderedHtml = '';
+  renderSeatsGrid(status);
 }

--- a/highsociety/web/static/js/network/messages.js
+++ b/highsociety/web/static/js/network/messages.js
@@ -5,14 +5,15 @@
 // expected and safe: every one of these is only ever touched inside a
 // function body (never at this module's own top-level evaluation), by
 // which point every module involved has finished loading.
-import { $, showError, showScreen } from '../utils/dom.js';
+import { $, hide, show, showError, showScreen } from '../utils/dom.js';
 import { setSessionStatus } from '../auth/profile.js';
 import { game } from '../game/gameState.js';
 import { applyGameMessage, ensureGameScreenVisible } from '../game/gameEvents.js';
 import { ws } from './websocket.js';
-import { currentRoomCode, clearRejoinInfo, saveRejoinInfo } from '../lobby/lobby.js';
+import { currentRoomCode, clearRejoinInfo, saveRejoinInfo, leaveToHome } from '../lobby/lobby.js';
 import { startWaitingRoomPolling } from '../lobby/playerList.js';
 import { handleRematchMessage } from '../lobby/rematch.js';
+import { showToast } from '../ui/notifications.js';
 
 // pendingJoin/pendingSpectate: the {username, name} this connection is
 // identifying as, set right before opening the socket (see lobby.js's
@@ -65,6 +66,8 @@ export function handlePlayerMessage(msg) {
         showScreen('screen-join');
         $('join-form').classList.add('hidden');
         $('join-waiting').classList.add('hidden');
+        hide($('lobby-seats-wrap'));
+        show($('lobby-status'));
         $('lobby-status').textContent = msg.prompt || 'A game is already in progress. You can watch as a spectator.';
       } else {
         pendingIdentifyError = msg.prompt;
@@ -96,6 +99,17 @@ export function handlePlayerMessage(msg) {
     case 'REMATCH_DECLINED':
     case 'REMATCH_STARTING':
       handleRematchMessage(msg);
+      break;
+    // The host removed this player from a lobby that hasn't started yet
+    // (see web_server.py's api_remove_seat) -- this only ever arrives while
+    // still waiting, so there's no live game underneath to protect; skip
+    // applyGameMessage() entirely (its ensureGameScreenVisible() call makes
+    // no sense here) and just tell them, then send them home the same way
+    // "Return to Home" already does.
+    case 'KICKED':
+      ws.close();
+      showToast((msg.data && msg.data.reason) || 'You were removed from this game.');
+      leaveToHome();
       break;
     default:
       applyGameMessage(msg, false);

--- a/highsociety/web/templates/index.html
+++ b/highsociety/web/templates/index.html
@@ -1210,7 +1210,24 @@
             <span>Copy</span>
           </button>
         </div>
-        <div id="lobby-status" class="lobby-status"></div>
+        <!-- Plain text fallback -- reconnect failure / "already in progress"
+             messages (see network/messages.js, lobby.js's renderForStatus)
+             that aren't real seat data, so they don't belong in the grid
+             below. Never shown at the same time as #lobby-seats-wrap. -->
+        <div id="lobby-status" class="lobby-status hidden"></div>
+
+        <!-- Real per-seat grid (see JOIN_GAME_REWORK.MD) -- built by
+             playerList.js from the same live roster poll that used to
+             render as a single "Seats filled: x/y (...)" sentence. The
+             host (or anyone, in a room with no host on record -- see
+             web_server.py's _is_room_host) gets inline controls here to
+             add a bot to an open seat or remove any seat; everyone else
+             sees the identical grid read-only. -->
+        <div id="lobby-seats-wrap" class="hidden">
+          <p id="lobby-seats-label" class="lobby-seats-label"></p>
+          <div id="lobby-seats" class="lobby-seats"></div>
+          <p id="lobby-seats-error" class="error hidden"></p>
+        </div>
 
         <div id="join-form">
           <p id="join-as-label" class="hidden">Joining as <strong id="join-as-name"></strong>.
@@ -1224,20 +1241,10 @@
 
         <div id="join-waiting" class="hidden">
           <p>✅ You're in! Waiting for the rest of the table…</p>
-          <div class="bot-add-row">
-            <label class="bot-add-label" for="waiting-bot-type">
-              Fill an empty seat with
-              <span class="bot-add-select-wrap">a
-                <select id="waiting-bot-type">
-                  <option value="easy">Easy</option>
-                  <option value="medium" selected>Medium</option>
-                  <option value="hard">Hard</option>
-                </select>
-                bot</span>
-            </label>
-            <button id="btn-add-bot" class="secondary">Add</button>
-          </div>
-          <p id="add-bot-error" class="error hidden"></p>
+          <!-- Adding/removing a seat now happens inline in the grid above
+               (host-only -- see .lobby-seat-add-btn/.lobby-seat-remove and
+               #lobby-seats-error for its errors); nothing left to show
+               here besides the confirmation line itself. -->
         </div>
 
         <button id="btn-spectate-link" class="secondary standalone">Watch as a spectator instead</button>

--- a/tests/network/test_protocol.py
+++ b/tests/network/test_protocol.py
@@ -117,6 +117,24 @@ class TestReactionPayload:
         assert payload["data"] == {"emoji": "🔥"}
 
 
+class TestKickedPayload:
+    """Regression coverage for the exact same class of bug TestReactionPayload
+    documents above: web_server.py's api_remove_seat sent message_type="KICKED"
+    before it was ever added to PLAYER_MESSAGE_TYPES, which raised ValueError
+    from inside the Flask request handler (caught here at the protocol layer
+    instead of only live, unlike REACTION's — see tests/network/test_web_server.py's
+    test_remove_seat_kicks_a_human_and_notifies_them for the end-to-end half)."""
+
+    def test_player_payload_accepts_kicked_with_reason_data(self):
+        payload = build_player_payload(
+            game_id="g1", username="alice", message_type="KICKED", prompt="",
+            data={"reason": "The host removed you from this game."},
+        )
+        assert payload["message_type"] == "KICKED"
+        assert payload["data"] == {"reason": "The host removed you from this game."}
+        assert "player_id" not in payload  # GLOBAL_EVENT-shaped, not addressed to a specific player_id
+
+
 class TestStructuredDataField:
     """data lets any broadcast carry machine-parseable content (e.g. AUCTION_RESULT)
     alongside its human-readable prompt — this is what a bot actually parses."""

--- a/tests/network/test_web_server.py
+++ b/tests/network/test_web_server.py
@@ -346,6 +346,115 @@ def test_add_bot_fills_an_empty_seat_and_can_start_the_game(running_web_server):
     assert non_preset.status_code == 400
 
 
+def test_status_reports_host_username(running_web_server):
+    client = web_server.app.test_client()
+    room_code = client.post(
+        "/api/create_game", json={"seats": 2, "bot_mix": [], "host_username": "alice"}
+    ).get_json()["room_code"]
+    assert client.get(f"/api/status?room={room_code}").get_json()["host_username"] == "alice"
+
+
+def test_add_bot_is_host_only_once_a_host_is_known(running_web_server):
+    client = web_server.app.test_client()
+    room_code = client.post(
+        "/api/create_game", json={"seats": 3, "bot_mix": [], "host_username": "alice"}
+    ).get_json()["room_code"]
+
+    # No requester, or the wrong requester -- rejected.
+    denied = client.post("/api/add_bot", json={"room": room_code, "bot_type": "greedy"})
+    assert denied.status_code == 403
+    wrong_user = client.post(
+        "/api/add_bot", json={"room": room_code, "bot_type": "greedy", "requester_username": "mallory"}
+    )
+    assert wrong_user.status_code == 403
+    assert web_server._rooms[room_code].players == []  # neither attempt actually added anything
+
+    # The real host succeeds.
+    ok = client.post(
+        "/api/add_bot", json={"room": room_code, "bot_type": "greedy", "requester_username": "alice"}
+    )
+    assert ok.status_code == 200
+    assert len(ok.get_json()["joined"]) == 1
+
+
+def test_add_bot_stays_open_to_anyone_when_no_host_is_known(running_web_server):
+    """A room created without a host_username (an older client, or a
+    matchmaking-created room) has no host concept -- add_bot must keep
+    working exactly as it did before this host-only restriction existed."""
+    client = web_server.app.test_client()
+    room_code = client.post("/api/create_game", json={"seats": 2, "bot_mix": []}).get_json()["room_code"]
+
+    resp = client.post("/api/add_bot", json={"room": room_code, "bot_type": "greedy"})
+    assert resp.status_code == 200
+
+
+def test_remove_seat_removes_a_bot_and_reverses_its_bookkeeping(running_web_server):
+    port = running_web_server
+    client = web_server.app.test_client()
+    room_code = client.post(
+        "/api/create_game", json={"seats": 3, "bot_mix": [], "host_username": "alice"}
+    ).get_json()["room_code"]
+    added = client.post(
+        "/api/add_bot", json={"room": room_code, "bot_type": "greedy", "requester_username": "alice"}
+    ).get_json()
+    assert added["human_seats"] == 2
+    bot_username = added["joined"][0]["username"]
+
+    denied = client.post(
+        "/api/remove_seat", json={"room": room_code, "username": bot_username, "requester_username": "mallory"}
+    )
+    assert denied.status_code == 403
+
+    resp = client.post(
+        "/api/remove_seat", json={"room": room_code, "username": bot_username, "requester_username": "alice"}
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["joined"] == []
+    assert body["human_seats"] == 3  # back to fully open, same as before the bot was added
+    assert web_server._rooms[room_code].bot_mix == []
+
+    missing = client.post(
+        "/api/remove_seat", json={"room": room_code, "username": "nobody", "requester_username": "alice"}
+    )
+    assert missing.status_code == 404
+
+    # The host can't remove themselves -- but only once they're actually a
+    # seated player; before that (as above), there's simply no such player
+    # to find yet, hence the 404 rather than this 400.
+    host = ScriptedWSClient(_ws_url(port, f"/ws?room={room_code}"), "alice")
+    host.handshake()
+    host.start()
+    self_removal = client.post(
+        "/api/remove_seat", json={"room": room_code, "username": "alice", "requester_username": "alice"}
+    )
+    assert self_removal.status_code == 400
+
+
+def test_remove_seat_kicks_a_human_and_notifies_them(running_web_server):
+    port = running_web_server
+    client = web_server.app.test_client()
+    room_code = client.post(
+        "/api/create_game", json={"seats": 2, "bot_mix": [], "host_username": "alice"}
+    ).get_json()["room_code"]
+
+    victim = ScriptedWSClient(_ws_url(port, f"/ws?room={room_code}"), "bob")
+    victim.handshake()
+    victim.start()
+
+    resp = client.post(
+        "/api/remove_seat", json={"room": room_code, "username": "bob", "requester_username": "alice"}
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["joined"] == []
+
+    deadline = time.time() + 5
+    while time.time() < deadline and not victim.messages_of_type("KICKED"):
+        threading.Event().wait(0.1)
+    assert victim.messages_of_type("KICKED"), "kicked player was never notified"
+    assert "bob" not in [p.username for p in web_server._rooms[room_code].players]
+
+
 def test_player_receives_a_live_countdown_when_the_host_sets_a_turn_time_limit(running_web_server):
     port = running_web_server
     room_code = web_server.app.test_client().post(

--- a/web_server.py
+++ b/web_server.py
@@ -1059,6 +1059,7 @@ def _status_payload(room: Optional[GameRoom]) -> dict:
         "visibility": room.visibility,
         "state": room.state,
         "game_id": room.game_id,
+        "host_username": room.host_username,
         "seats": room.seats,
         "human_seats": room.human_seats,
         "bot_mix": room.bot_mix,
@@ -1120,13 +1121,27 @@ def api_rooms():
     return jsonify({"rooms": rooms})
 
 
+def _is_room_host(room: "GameRoom", requester_username: Optional[str]) -> bool:
+    """
+    True if `requester_username` may manage this room's seats (add/remove a
+    bot, kick a human). A room created without a known host (host_username
+    is None — an older client, or a matchmaking-created room; see
+    GameRoom.host_username's own comment) has no host concept at all, so
+    seat management stays open to anyone in it, exactly as it always has
+    been — this only *adds* a restriction where a host is actually known,
+    it never takes away access nothing previously required.
+    """
+    return room.host_username is None or requester_username == room.host_username
+
+
 @app.route("/api/add_bot", methods=["POST"])
 def api_add_bot():
     """
-    Lets anyone already waiting in a room's lobby fill an empty seat with a
-    bot — e.g. one friend backs out at the last minute and nobody wants to
-    wait around for a replacement. Same effect as configuring more bots at
-    creation time, just usable after the room already exists.
+    Lets the host of a room's lobby fill an empty seat with a bot — e.g. one
+    friend backs out at the last minute and nobody wants to wait around for
+    a replacement. Same effect as configuring more bots at creation time,
+    just usable after the room already exists. See _is_room_host for why
+    this is only host-only when a host is actually known.
     """
     body = request.get_json(silent=True) or {}
     room = _get_room(body.get("room"))
@@ -1138,6 +1153,8 @@ def api_add_bot():
         return jsonify({"error": f"Unknown bot type; choose from {list(BOT_TYPES)}"}), 400
 
     with room.lock:
+        if not _is_room_host(room, body.get("requester_username")):
+            return jsonify({"error": "Only the host can add a bot."}), 403
         if room.state != "lobby":
             return jsonify({"error": "This game has already started."}), 409
         if len(room.players) >= room.seats:
@@ -1152,6 +1169,70 @@ def api_add_bot():
 
     if room.try_start():
         room.run_game()
+
+    return jsonify(_status_payload(room))
+
+
+@app.route("/api/remove_seat", methods=["POST"])
+def api_remove_seat():
+    """
+    Host-only: frees up a seat in a still-open lobby, whether it's occupied
+    by a bot or a human (see _is_room_host for the same "no known host means
+    open to anyone" fallback add_bot uses).
+
+    Removing a bot is immediate and silent — just an inverse of add_bot,
+    including reversing its room.bot_mix/human_seats bookkeeping (matched
+    back to a bot_mix entry via its class in BOT_TYPES, since a bot has no
+    other record of which difficulty it was created as).
+
+    Removing a human is not a plain list removal: they're mid-connection
+    (see ws_player), so their own _run_player_session loop is what actually
+    detaches them once notified. This handler sends them a KICKED message
+    (network/messages.js's frontend counterpart shows a toast and redirects
+    home, deliberately not routed through the normal game-message path —
+    see that file's own comment) and closes their transport; that flips
+    NetworkPlayer.active to False, which ws_player's own tail (the
+    lobby-disconnect cleanup already used for a plain dropped connection)
+    removes from room.players. Removing them from room.players here too,
+    inside this same lock, means the very next /api/status poll already
+    reflects it rather than racing that connection's teardown.
+    """
+    body = request.get_json(silent=True) or {}
+    room = _get_room(body.get("room"))
+    if room is None:
+        return jsonify({"error": "No such room."}), 404
+
+    target_username = body.get("username")
+    if not target_username:
+        return jsonify({"error": "username is required."}), 400
+
+    kicked_player = None
+    with room.lock:
+        if not _is_room_host(room, body.get("requester_username")):
+            return jsonify({"error": "Only the host can remove a seat."}), 403
+        if room.state != "lobby":
+            return jsonify({"error": "This game has already started."}), 409
+
+        target = next((p for p in room.players if p.username == target_username), None)
+        if target is None:
+            return jsonify({"error": "No such player in this room."}), 404
+        if room.host_username is not None and target_username == room.host_username:
+            return jsonify({"error": "The host can't remove themselves."}), 400
+
+        room.players.remove(target)
+        if isinstance(target, NetworkPlayer):
+            kicked_player = target
+            room.rejoin_tokens = {t: u for t, u in room.rejoin_tokens.items() if u != target_username}
+        else:
+            bot_type = next((bt for bt in room.bot_mix if isinstance(target, BOT_TYPES[bt])), None)
+            if bot_type is not None:
+                room.bot_mix.remove(bot_type)
+            room.human_seats += 1  # this seat is available for a human again
+        room.touch()
+
+    if kicked_player is not None:
+        kicked_player.send_message("", message_type="KICKED", data={"reason": "The host removed you from this game."})
+        kicked_player.close()
 
     return jsonify(_status_payload(room))
 


### PR DESCRIPTION
## Summary
Implements JOIN_GAME_REWORK.MD (+ a smaller visual pass from JOIN_GAME_NON_HOST_UI.MD): host-only bot add/remove and human kicking in the waiting room, rendered as a real per-seat grid instead of a plain text line.

**Backend**
- `_status_payload` now reports `host_username`.
- `/api/add_bot` is host-only once a host is known (`_is_room_host`); rooms with no known host (older clients, matchmaking rooms) stay open to anyone, unchanged from before.
- New `POST /api/remove_seat` (host-only): removes a bot (reversing its `bot_mix`/`human_seats` bookkeeping) or kicks a human, who gets a live `KICKED` WebSocket message before their connection is closed.
- Registered `KICKED` in `protocol.py`'s `PLAYER_MESSAGE_TYPES` (same class of bug the existing `TestReactionPayload` regression test documents — caught here via the new test coverage before it ever shipped).

**Frontend**
- `messages.js`: `KICKED` shows a toast and redirects to Home, same special-casing as `REMATCH_*`.
- `playerList.js`: real seat grid — inline add-a-bot (easy/medium/hard) on open seats, hover-reveal remove on occupied ones, both host-only; a successful action repaints immediately from the response instead of waiting for the next 1.5s poll tick.
- `lobby.js`: public-games list now shows a seat-fill progress bar instead of bare "(4/5 seats filled)" text.

## Testing
- Full backend suite: 531 passed.
- Live Playwright pass: host add/remove-bot, a non-host's read-only view, and a full kick-a-human flow (toast + redirect confirmed on the kicked browser) — 19/19 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)