### PR TITLE
Account/Player Profile layout rework + Elo placement fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,3 +28,41 @@ Before calling a visual fix complete:
    pattern (other back links, other form fields, other panels) for
    consistency, since a shared CSS rule affecting one often affects others
    the same way.
+
+## Loading state: reserve the layout, never hide-then-reveal a tile
+
+A tile/section whose content depends on an async fetch must keep the
+same footprint whether it's loading or has real data. Show a loading
+spinner (`.tile-loading-spinner`, see `lobby.css`) or skeleton *inside*
+the tile's already-reserved slot; never toggle the tile's own
+`.hidden`/visibility based on whether its data has arrived yet. If
+there's genuinely no data once the fetch resolves (a new player with no
+games, a guest with no rated history), replace the loading state with a
+short explanatory message *in that same slot* — still never collapsing
+or hiding the tile itself.
+
+Two related real bugs this fixes:
+- **Layout shift / relocation**: a tile that stays hidden until its
+  fetch resolves, sitting above another tile that resolves faster,
+  visibly shoves that second tile down (or "relocates" it) once the
+  slower one finally pops in. Reserving the slot up front — synchronously
+  if the caller already knows enough to decide (e.g. a local
+  `profile.google_id` check), or via a fixed-size loading state
+  otherwise — eliminates this regardless of which fetch finishes first.
+- **"Loading one tile at a time"**: several independently-loading tiles
+  on one screen, each hidden until its own data arrives, reads as the
+  whole screen loading sequentially even when every fetch actually
+  started in parallel — because visually nothing appears until each one
+  individually finishes. Reserving every tile's slot immediately (all in
+  their own loading state) makes the parallelism visible instead of
+  looking accidental.
+
+Concrete example from this project: the Account/Player Profile screens'
+Elo chart used to live in its own tile, hidden until an async fetch (plus
+a real charting library load, the first time it's needed) resolved —
+whenever that took longer than the Game History tile below it, Game
+History would settle in first and then visibly get pushed down once the
+chart popped in late. Fixed by making the chart tile (and Game History)
+permanently part of the layout, each swapping only their own internal
+content between a spinner, real data, or an empty-state message — see
+`ui/eloChart.js`'s own module comment for the full writeup.

--- a/highsociety/code/common/db/game_history.py
+++ b/highsociety/code/common/db/game_history.py
@@ -1656,7 +1656,16 @@ def record_finished_game(*, room_code: str, seats: int, bot_mix: list,
                 is_rated = player_id is not None and (google_id is not None or p["is_bot"])
                 if is_rated:
                     rating_key = p.get("game_username") or p["username"]
-                    rated_standings.append({"username": rating_key, "points": p["points"], "rating": elo_before})
+                    # placement, not raw points -- see elo.compute_elo_deltas'
+                    # own docstring on why: this game's real winner is
+                    # whoever scored highest *among players not eliminated*
+                    # for having the least money, so the points leader can
+                    # genuinely finish last (placement_by_index above
+                    # already accounts for this correctly; points alone
+                    # never did).
+                    rated_standings.append({
+                        "username": rating_key, "placement": placement_by_index[index], "rating": elo_before,
+                    })
                     rated_player_ids[rating_key] = player_id
                     elo_before_by_player_id[player_id] = elo_before
 

--- a/highsociety/code/common/elo.py
+++ b/highsociety/code/common/elo.py
@@ -3,8 +3,8 @@ Multiplayer Elo rating updates. A card game's result is a full ranking of
 N players (see PlayGame.final_standings), not a single winner/loser pair
 -- the standard two-player Elo formula doesn't directly apply. This uses
 the common "pairwise" generalization: for every pair of players in the
-game, treat the outcome as if they'd played a 1v1 (whoever scored more
-points "won" that pair, equal points is a draw), compute the usual Elo
+game, treat the outcome as if they'd played a 1v1 (whoever placed better
+"won" that pair, an equal placement is a draw), compute the usual Elo
 expected-score delta for that pair, and average each player's deltas
 across every pair they're part of -- averaging (not summing) keeps a
 game's total rating swing comparable across table sizes, since a 5-player
@@ -24,20 +24,31 @@ DEFAULT_K_FACTOR = 32
 
 def compute_elo_deltas(standings: list, k_factor: float = DEFAULT_K_FACTOR) -> dict:
     """
-    standings: one dict per rated player -- {"username", "points", "rating"}
-    (their Elo *before* this game). Only ever called with participants
-    whose rating actually means something persistent: a Google-linked
-    human (a guest's identity resets on every browser clear, so there's
-    nothing meaningful to track a rating against -- same reasoning as
-    achievements.py's own gating), or a bot with a known difficulty (see
-    game_history.py's `bots` table -- each difficulty tier has one
-    shared, real, evolving rating of its own, used here exactly like a
-    human's so a human's rating actually moves in practice against the
-    overwhelmingly common solo-vs-bots case, but never surfaced to
-    players anywhere in the UI). "username" here is whatever key the
-    caller used to identify each participant -- not necessarily a real
-    players.username, see game_history.py's `game_username` for why a
-    bot needs a different one.
+    standings: one dict per rated player -- {"username", "placement",
+    "rating"} (their Elo *before* this game). `placement` is this
+    player's final rank (1 = actual game winner, matching
+    game_history.py's own placement_by_index) -- NOT raw points: this
+    game's real winner is whoever has the most points *among players not
+    eliminated* for having the least money (see PlayGame's own win
+    condition), so the points leader can genuinely finish last. A real
+    bug, confirmed live: rating deltas used to compare raw points
+    directly, so an eliminated player with the game's highest score still
+    gained Elo despite finishing dead last by the game's own rules --
+    exactly the "why did my rating go up when I lost" case placement
+    (unlike points) already accounts for correctly.
+
+    Only ever called with participants whose rating actually means
+    something persistent: a Google-linked human (a guest's identity
+    resets on every browser clear, so there's nothing meaningful to
+    track a rating against -- same reasoning as achievements.py's own
+    gating), or a bot with a known difficulty (see game_history.py's
+    `bots` table -- each difficulty tier has one shared, real, evolving
+    rating of its own, used here exactly like a human's so a human's
+    rating actually moves in practice against the overwhelmingly common
+    solo-vs-bots case, but never surfaced to players anywhere in the UI).
+    "username" here is whatever key the caller used to identify each
+    participant -- not necessarily a real players.username, see
+    game_history.py's `game_username` for why a bot needs a different one.
 
     Returns {username: delta} (whole numbers, can be negative). Fewer
     than 2 rated players means there's no comparison to make -- returns
@@ -53,9 +64,10 @@ def compute_elo_deltas(standings: list, k_factor: float = DEFAULT_K_FACTOR) -> d
     for i in range(len(standings)):
         for j in range(i + 1, len(standings)):
             a, b = standings[i], standings[j]
-            if a["points"] > b["points"]:
+            # Lower placement number is the better finish (1st beats 2nd).
+            if a["placement"] < b["placement"]:
                 score_a, score_b = 1.0, 0.0
-            elif a["points"] < b["points"]:
+            elif a["placement"] > b["placement"]:
                 score_a, score_b = 0.0, 1.0
             else:
                 score_a = score_b = 0.5

--- a/highsociety/web/static/css/lobby.css
+++ b/highsociety/web/static/css/lobby.css
@@ -274,6 +274,37 @@
   50% { opacity: 0.8; }
 }
 
+/* Stats and the Elo chart side by side (see index.html's own comment on
+   the Account/Player Profile tile that holds this) -- reported as both
+   looking oversized once there was a reference layout showing them this
+   way, and as the actual cause of a real layout-shift bug: the chart's
+   own separate tile settling in later than everything around it visibly
+   relocated whatever came after it. Single column below 641px -- a
+   6-stat grid squeezed into half of an already-narrow phone screen
+   reads worse than just stacking normally, so mobile keeps the stats
+   grid's original full-width sizing (its own <480px 2-column rule still
+   applies underneath this). */
+.account-stats-chart-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+  align-items: start;
+  margin-top: 1.2rem;
+}
+@media (max-width: 640px) {
+  .account-stats-chart-row { grid-template-columns: 1fr; gap: 1rem; }
+}
+.account-stats-chart-row .account-stats-row { margin-top: 0; }
+@media (min-width: 641px) {
+  .account-stats-chart-row .account-stats-grid { grid-template-columns: repeat(2, 1fr); gap: 0.5rem; }
+  .account-stats-chart-row .account-stat { padding: 0.5rem 0.4rem; }
+  .account-stats-chart-row .account-stat-value { font-size: 1.05rem; }
+  .account-stats-chart-row .account-stat-label { font-size: 0.68rem; }
+  .account-stats-chart-row .account-stat-icon { width: 18px; height: 18px; }
+  .account-stats-chart-row .account-stat-icon svg { width: 10px; height: 10px; }
+}
+.account-elo-chart-col h3 { margin-bottom: 0.5rem; }
+
 /* A small icon badge inline with a section heading -- not scoped to any
    one screen: "Elo progress" and "Game History" on Account, and "Game
    History" on Home, all opt in via this same .section-icon class, matching
@@ -311,19 +342,29 @@ h3:has(.section-icon) { display: flex; align-items: center; gap: 0.5rem; }
    observed, even with height:200 and the legend/toolbar both disabled),
    which silently grows the tile 15px past the size actually asked for
    ("too large" was the original complaint) unless overridden here. */
-.account-elo-chart { width: 100%; height: 200px; min-height: 200px !important; overflow: hidden; position: relative; }
-/* Same pulsing-placeholder language as the stat cards above (so "still
-   loading" reads consistently within this one screen), plus a real
-   spinning ring centered on top -- this tile's own wait is longer and
-   more variable than a plain stat card's (a network fetch *and* a
-   ~500KB charting library the first time it's ever needed), so a flat
-   pulsing block alone read as inert rather than actively working. */
-.account-elo-chart.loading {
+/* Shrunk from 200px -- reported as too large once it's sharing a row
+   with the (also now smaller) stats grid instead of owning the full
+   tile width on its own. ui/eloChart.js's own numeric chart.height
+   config must stay in sync with this value (see its own comment on why
+   a percentage height isn't reliable here). */
+.account-elo-chart { width: 100%; height: 160px; min-height: 160px !important; overflow: hidden; position: relative; }
+/* Reusable "this content area is loading" treatment -- a pulsing tint
+   (same skeleton language the plain-text stat cards use, via
+   stat-skeleton-pulse) plus a real spinning ring centered on top, for
+   any tile whose wait is longer/more variable than a stat card's simple
+   text swap (a network fetch, sometimes *and* a real external library
+   the first time it's ever needed -- see the Elo chart). Applies
+   wherever a tile is meant to keep its footprint constant and just show
+   this in place while loading, rather than the tile itself being
+   hidden/revealed -- the Elo chart and Game History both use it (see
+   index.html/account.js/playerProfile.js). */
+.tile-loading-spinner {
+  position: relative;
   border-radius: var(--radius-sm);
   background: var(--panel-bg-soft);
   animation: stat-skeleton-pulse 1.4s ease-in-out infinite;
 }
-.account-elo-chart.loading::after {
+.tile-loading-spinner::after {
   content: "";
   position: absolute;
   top: 50%;
@@ -366,6 +407,11 @@ h3:has(.section-icon) { display: flex; align-items: center; gap: 0.5rem; }
 }
 .account-elo-chart-range-btn:hover { border-color: var(--accent-light); }
 .account-elo-chart-range-btn.selected { background: var(--accent); border-color: var(--accent); color: #fff; }
+/* Disabled whenever there's genuinely nothing to filter (see
+   ui/eloChart.js's setRangeToggleEnabled) -- without this, a disabled
+   pill looked identical to a clickable one, misleadingly. */
+.account-elo-chart-range-btn:disabled { opacity: 0.45; cursor: default; }
+.account-elo-chart-range-btn:disabled:hover { border-color: var(--panel-border); }
 
 /* Locked tiles are fully desaturated (grayscale + faded) so an unlock reads
    as a real color reveal, not just a border/shadow change. Icon badge
@@ -755,6 +801,25 @@ h3:has(.section-icon) { display: flex; align-items: center; gap: 0.5rem; }
    demo/gallery tile specifically needs on top of that. */
 .rules-card-tile .status-card { position: relative; }
 .rules-card-tile .status-card .green-dot { top: 6px; right: 6px; }
+
+/* Same green as the live game's own money chips (.chip.money) -- a
+   plain static swatch here rather than reusing that class directly,
+   since .chip bakes in cursor:pointer/hover-lift meant for an actually
+   clickable bid chip, which would be misleading on a page that's just
+   illustrating what the cards look like. */
+.rules-money-gallery { display: flex; flex-wrap: wrap; gap: 0.5rem; margin: 0.7rem 0; }
+.rules-money-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.4rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: var(--radius-card);
+  background: var(--chip-money);
+  color: #fff;
+  font-weight: 700;
+  font-size: 0.9rem;
+}
 
 /* ---------------- how to play: scripted auction demo ---------------- */
 /* See rulesDemo.js -- entirely canned/fixed data, no backend or real
@@ -1413,6 +1478,11 @@ button.secondary.standalone { margin-top: 0.9rem; display: inline-block; }
 /* ---------------- recent games / My Games (Part G) ---------------- */
 
 .recent-games-list { display: flex; flex-direction: column; gap: 0.4rem; margin-top: 0.8rem; }
+/* With zero rows in it yet (the loading state, before any row exists to
+   give it real height), .tile-loading-spinner would otherwise collapse
+   to 0 height and its own spinner/pulse would have nothing to paint
+   into. */
+.recent-games-list.tile-loading-spinner { min-height: 88px; }
 /* A row -- rank badge, opponents/date, a chevron -- rather than two
    stacked lines with the placement pill floating at the top: reads more
    like a real list of clickable rows (the chevron is the "this opens

--- a/highsociety/web/static/css/main.css
+++ b/highsociety/web/static/css/main.css
@@ -485,7 +485,7 @@ input.needs-attention {
   /* A continuously-spinning ring is more insistent motion than the
      screen-settle fade above -- left as a static ring (still reads as
      "loading"), not hidden outright. */
-  .account-elo-chart.loading::after { animation: none; }
+  .tile-loading-spinner::after { animation: none; }
 }
 
 .panel {

--- a/highsociety/web/static/js/account/account.js
+++ b/highsociety/web/static/js/account/account.js
@@ -174,25 +174,29 @@ async function loadAccountStats() {
 // The actual ApexCharts implementation lives in ui/eloChart.js now,
 // shared with a public Player Profile's own identical chart (see
 // lobby/playerProfile.js) -- this screen just owns one controller
-// instance pointed at its own ids.
+// instance pointed at its own ids. No sectionId any more -- the chart's
+// own tile is a permanent part of the layout now (see index.html's own
+// comment on .account-stats-chart-row), never hidden as a whole.
 const eloChartController = createEloChartController({
   containerId: 'account-elo-chart',
-  sectionId: 'account-elo-chart-section',
   rangeToggleId: 'account-elo-chart-range-toggle',
 });
 export function onEloChartRangeClick(e) { eloChartController.onRangeClick(e); }
 
 // Guests never accrue real rating history (record_finished_game only
 // rates google_id-linked players -- same gate account-elo's own Unrated
-// label already uses), so there's nothing meaningful to plot -- the
-// section stays hidden rather than showing an empty chart.
-// The section's own visibility for the "no profile / not Google-linked"
-// case is already decided synchronously in showAccountScreen (before this
-// even starts) -- checked again here only defensively, in case this is
-// ever called from somewhere that skipped that step.
+// label already uses), so there's nothing meaningful to plot -- shows a
+// plain explanation in the chart's own slot instead of an empty chart
+// (or, as before this screen reserved its layout permanently, hiding
+// the whole tile).
 async function loadEloChart(profile) {
-  if (!profile || !profile.google_id) { hide($('account-elo-chart-section')); return; }
-  await eloChartController.load(`/api/profile/${encodeURIComponent(profile.username)}/rating_history`);
+  if (!profile || !profile.google_id) {
+    eloChartController.showUnavailable('Sign in with Google to start tracking your Elo rating.');
+    return;
+  }
+  await eloChartController.load(`/api/profile/${encodeURIComponent(profile.username)}/rating_history`, {
+    emptyMessage: 'No rated games yet.',
+  });
 }
 
 // -------------------------------------------------------- recent activity --
@@ -209,20 +213,21 @@ async function loadEloChart(profile) {
 // fetch this session (e.g. a deep link straight to /account) pays for a
 // real round trip, same as Home's own widget would have anyway.
 async function loadRecentActivity(profile) {
-  const section = $('account-recent-activity-section');
   const list = $('account-recent-activity-list');
-  if (!profile) { hide(section); return; }
+  const empty = $('account-recent-activity-empty');
+  if (!profile) { list.classList.remove('tile-loading-spinner'); show(empty); return; }
   const paint = (page) => {
     const games = page.games.slice(0, 5);
-    if (games.length === 0) { hide(section); return; }
+    list.classList.remove('tile-loading-spinner');
+    if (games.length === 0) { list.innerHTML = ''; show(empty); return; }
+    hide(empty);
     renderIfChanged(list, games, profile.username);
-    show(section);
   };
   const { cached, freshPromise } = fetchGamesPage(profile.username, 0);
   if (cached) paint(cached);
   const fresh = await freshPromise;
   if (fresh) paint(fresh);
-  else if (!cached) hide(section);
+  else if (!cached) { list.classList.remove('tile-loading-spinner'); show(empty); }
 }
 
 // Cached per username, in memory for this tab's lifetime -- an unlocked
@@ -299,29 +304,16 @@ export function showAccountScreen() {
   hide($('account-error'));
   hide($('account-saved'));
   $('account-meta-row').classList.add('loading');
-  // The chart tile's own visibility is decided synchronously, right here,
-  // rather than staying hidden until its (slower) async fetch resolves --
-  // a real, reported bug: whenever the chart happened to take longer to
-  // load than Recent Activity below it (a fresh network fetch plus a real
-  // ~500KB charting library, vs. Recent Activity's near-instant cached
-  // paint), the chart tile would pop into existence *after* the screen had
-  // already settled, visibly shoving Recent Activity down without warning.
-  // google_id is already known synchronously (it's on the local profile,
-  // no fetch needed) and is the same condition loadEloChart's own guard
-  // uses, so reserving the space for it up front is safe in the common
-  // case; the rare remaining edge case (a Google account with zero rated
-  // games so far) still collapses it back down once the fetch confirms
-  // that, but that's a far rarer, smaller correction than every single
-  // successful load shifting late. See loadEloChart/renderEloChart's own
-  // comments for the other half of this.
-  $('account-elo-chart').classList.add('loading');
-  $('account-elo-chart-section').classList.toggle('hidden', !(profile && profile.google_id));
-  // Recent Activity has no equivalent slow-external-library concern, so
-  // it keeps the simpler "hidden until its own data says otherwise"
-  // behavior -- reset here for the same account-switch reason as before
+  // Neither the Elo chart nor Game History are ever hidden as a whole any
+  // more (see .account-stats-chart-row's own comment in index.html) --
+  // both tiles are a permanent part of this screen's layout, and this
+  // just resets their own *internal* loading state for a fresh profile
   // (logging out of a Google account with real data, back in as a fresh
-  // guest, shouldn't flash the previous profile's feed for a moment).
-  hide($('account-recent-activity-section'));
+  // guest, shouldn't flash the previous profile's chart/feed for a
+  // moment before the new one's own load overwrites it).
+  $('account-elo-chart').classList.add('tile-loading-spinner');
+  $('account-recent-activity-list').classList.add('tile-loading-spinner');
+  hide($('account-recent-activity-empty'));
   showScreen('screen-account');
   // Includes the username (chess.com-style) purely for a nicer/shareable
   // URL -- this is never a per-user viewer, so a stale or foreign

--- a/highsociety/web/static/js/lobby/gameHistory.js
+++ b/highsociety/web/static/js/lobby/gameHistory.js
@@ -172,13 +172,17 @@ async function loadHomeEloBadge(profile) {
 
 function paintHomeRecentGames(page, username, section) {
   const games = page.games.slice(0, 5);
-  // showHomeTile (lobby.js) hides this synchronously the instant a
+  // showHomeTile (lobby.js) hides #home-grid synchronously the instant a
   // sub-panel (Join/Host/Rules) is picked -- but this can resolve after
   // that happened, so it would otherwise un-hide it again on the wrong
   // screen (a real, reported bug: Recent Games appearing above the Host
-  // form). $('home-tiles') being hidden is exactly "no longer on the
-  // tile picker", regardless of which sub-panel is now showing instead.
-  if (games.length === 0 || $('home-tiles').classList.contains('hidden')) { hide(section); return; }
+  // form). $('home-grid') being hidden is exactly "no longer on the
+  // tile picker", regardless of which sub-panel is now showing instead
+  // (checking #home-tiles itself here used to work the same way, back
+  // when showHomeTile hid that element directly -- it now hides the
+  // whole #home-grid wrapper instead, see that function's own comment
+  // on why).
+  if (games.length === 0 || $('home-grid').classList.contains('hidden')) { hide(section); return; }
   const changed = renderIfChanged($('home-recent-games-list'), games, username);
   const alreadyShown = !section.classList.contains('hidden');
   if (changed || !alreadyShown) showEnter(section);

--- a/highsociety/web/static/js/lobby/lobby.js
+++ b/highsociety/web/static/js/lobby/lobby.js
@@ -136,12 +136,16 @@ export async function enterRoom(roomCode, event) {
 // home never leaves a stale panel expanded from a previous visit.
 const HOME_TILE_TARGETS = ['join', 'host', 'rules'];
 export function showHomeTile(target) {
-  hide($('home-tiles'));
-  // The global-stats/recent-games sections only make sense alongside the
-  // tile picker itself -- a sub-panel (e.g. the Host form) has no room or
-  // reason to show them too.
-  hide($('home-global-stats'));
-  hide($('home-recent-games'));
+  // Hiding the whole grid wrapper, not just #home-tiles inside it -- a
+  // real reported bug: #home-grid carries its own margin-top (the same
+  // --screen-top-gap every screen's top-level panel uses), and it never
+  // actually left the layout when only its *children* were hidden --
+  // an empty grid box, but still taking its own margin-top's worth of
+  // space above whichever sub-panel (Join/Host/Rules) rendered right
+  // after it. That pushed Join/Host/How to Play a full --screen-top-gap
+  // lower than Play/Leaderboard/Account, which never had this extra
+  // empty wrapper sitting above them.
+  hide($('home-grid'));
   HOME_TILE_TARGETS.forEach((t) => $(`home-panel-${t}`).classList.toggle('hidden', t !== target));
   setScreenPath(`/${target}`); // 'join'/'host'/'rules' -- matches web_server.py's static routes exactly
   // One less click for the single most common thing to do on this panel --
@@ -152,7 +156,7 @@ export function showHomeTile(target) {
   if (target === 'join') $('join-room-code').focus();
 }
 export function showHomeTiles() {
-  show($('home-tiles'));
+  show($('home-grid'));
   HOME_TILE_TARGETS.forEach((t) => hide($(`home-panel-${t}`)));
   setScreenPath('/');
   loadHomeGlobalStats();

--- a/highsociety/web/static/js/lobby/playerProfile.js
+++ b/highsociety/web/static/js/lobby/playerProfile.js
@@ -13,10 +13,12 @@ import { createEloChartController } from '../ui/eloChart.js';
 
 // Same shared chart Account's own screen uses (see ui/eloChart.js), a
 // separate controller instance so this screen's chart state (fetched
-// history, live chart object) is never confused with Account's own.
+// history, live chart object) is never confused with Account's own. No
+// sectionId -- the chart's own tile is a permanent part of the layout
+// (see index.html's .account-stats-chart-row comment), never hidden as
+// a whole.
 const eloChartController = createEloChartController({
   containerId: 'player-profile-elo-chart',
-  sectionId: 'player-profile-elo-chart-section',
   rangeToggleId: 'player-profile-elo-chart-range-toggle',
 });
 export function onPlayerProfileEloChartRangeClick(e) { eloChartController.onRangeClick(e); }
@@ -56,11 +58,11 @@ export function showPlayerProfileScreen(username, returnTo = 'leaderboard') {
   hide($('player-profile-meta-row'));
   hide($('player-profile-elo-hero'));
   $('player-profile-stats-row').classList.add('loading');
-  hide($('player-profile-elo-chart-section'));
-  $('player-profile-elo-chart').classList.add('loading');
-  hide($('player-profile-history-section'));
+  $('player-profile-elo-chart').classList.add('tile-loading-spinner');
+  $('player-profile-history-list').classList.add('tile-loading-spinner');
   $('player-profile-history-list').innerHTML = '';
   delete $('player-profile-history-list').dataset.renderedHtml; // a stale renderIfChanged memo from a *different* profile must never suppress this one's first real paint
+  hide($('player-profile-history-empty'));
 
   // All three run independently -- none awaits or blocks another, same as
   // Account's own screen-open already does. The chart's own relevance
@@ -69,7 +71,10 @@ export function showPlayerProfileScreen(username, returnTo = 'leaderboard') {
   // plausible than a login/logout cycle) could otherwise paint a slow
   // first fetch's stale data into a screen that's since moved on.
   loadPlayerProfileStats(username);
-  eloChartController.load(`/api/profile/${encodeURIComponent(username)}/rating_history`, () => username === profileUsername);
+  eloChartController.load(`/api/profile/${encodeURIComponent(username)}/rating_history`, {
+    isStillRelevant: () => username === profileUsername,
+    emptyMessage: 'No rated games yet.',
+  });
   loadPlayerProfileHistoryPage();
 }
 
@@ -126,16 +131,21 @@ async function loadPlayerProfileHistoryPage() {
   if (username !== profileUsername || offset !== profileOffset) return; // Prev/Next (or a whole new profile) already moved on
   if (fresh) paintPlayerProfileHistoryPage(fresh, username, offset);
   else if (!cached) {
-    hide($('player-profile-history-section'));
+    // A genuine fetch failure -- still just a message in the list's own
+    // slot, never hiding the tile around it (see this screen's own
+    // .account-stats-chart-row/tile-loading-spinner comments).
+    const list = $('player-profile-history-list');
+    list.classList.remove('tile-loading-spinner');
+    list.innerHTML = '';
+    show($('player-profile-history-empty'));
   }
 }
 
 function paintPlayerProfileHistoryPage(page, username, offset) {
-  const section = $('player-profile-history-section');
   const list = $('player-profile-history-list');
   const empty = $('player-profile-history-empty');
   const pagination = $('player-profile-history-pagination');
-  show(section);
+  list.classList.remove('tile-loading-spinner');
   if (page.games.length === 0 && offset === 0) {
     list.innerHTML = '';
     show(empty);

--- a/highsociety/web/static/js/ui/eloChart.js
+++ b/highsociety/web/static/js/ui/eloChart.js
@@ -7,7 +7,19 @@
 // instance), and even within one screen, navigating from one profile to
 // another needs a clean slate, not state left over from whoever was
 // viewed before.
-import { $, hide, show } from '../utils/dom.js';
+//
+// Deliberately never hides its own container -- a real reported bug:
+// this chart used to live in its own tile that stayed hidden until its
+// (slower) async fetch resolved, and whenever that took longer than
+// whatever sat around it, the chart would pop in *after* the screen had
+// already settled, visibly relocating everything below it. The caller
+// (account.js/playerProfile.js) now reserves this exact slot up front
+// and keeps it reserved permanently; this controller only ever swaps
+// what's *inside* the slot between a loading spinner (the container's
+// own .loading class, set by the caller before load() is even called),
+// the real chart, or a short explanation of why there's nothing to plot
+// -- never removing the slot itself.
+import { $ } from '../utils/dom.js';
 import { fetchJSON } from '../lobby/lobby.js';
 
 // Real axes/gridlines/tooltips via a real charting library, vendored
@@ -50,23 +62,41 @@ function filterHistoryByRange(history, range) {
   return history.filter((h) => new Date(h.created_at).getTime() >= cutoffMs);
 }
 
-// `containerId`/`sectionId`/`rangeToggleId`: the 3 elements every caller
-// of this chart already has (see index.html's Account and Player Profile
+// `containerId`/`rangeToggleId`: the two elements every caller of this
+// chart already has (see index.html's Account and Player Profile
 // markup, identical structure, different ids) -- a heading with a
-// .section-icon, the range-toggle button row, and the chart's own div.
-export function createEloChartController({ containerId, sectionId, rangeToggleId }) {
+// .section-icon sits above both, owned by the caller's own static HTML,
+// not this controller.
+export function createEloChartController({ containerId, rangeToggleId }) {
   let chart = null; // the live ApexCharts instance, if any
   let fullHistory = []; // the unfiltered fetch, so the 7D/30D/All toggle can re-slice without a new request
+
+  function setRangeToggleEnabled(enabled) {
+    document.querySelectorAll(`#${rangeToggleId} .account-elo-chart-range-btn`).forEach((b) => {
+      b.disabled = !enabled;
+    });
+  }
+
+  // A plain message in place of the chart -- used for "nothing to plot"
+  // (no rated games at all, a guest who hasn't signed in, ApexCharts
+  // itself failing to load) as well as filtered-empty ("no games in
+  // this 7D/30D window"). Never touches the container's own visibility,
+  // only what's inside it.
+  function renderMessage(text) {
+    if (chart) { chart.destroy(); chart = null; }
+    const container = $(containerId);
+    container.classList.remove('tile-loading-spinner');
+    container.innerHTML = `<p class="muted account-elo-chart-empty">${text}</p>`;
+  }
 
   // `history`: [{old_rating, new_rating, created_at}, ...] oldest first
   // (see get_rating_history), already narrowed to whatever range is
   // currently selected (see filterHistoryByRange) -- an empty array here
-  // means "no games in this window", which shows a small inline message
-  // rather than hiding the whole tile (the range toggle above it should
-  // stay reachable so a different window can still be picked). Plots
-  // every new_rating, prefixed by the very first entry's old_rating so
-  // the line actually starts somewhere instead of jumping in mid-air on
-  // its first point.
+  // means "no games in this window" (renderMessage handles it), not
+  // "nothing to plot at all" (load's own guard below handles that case
+  // before this is ever called). Plots every new_rating, prefixed by the
+  // very first entry's old_rating so the line actually starts somewhere
+  // instead of jumping in mid-air on its first point.
   //
   // A real datetime x-axis (each point keeps its actual timestamp)
   // rather than evenly-spaced-by-index -- an index-based layout would
@@ -78,22 +108,17 @@ export function createEloChartController({ containerId, sectionId, rangeToggleId
   // whole span back) purely so the line has a visible starting slope --
   // it's never a real game's own timestamp.
   async function render(history) {
+    if (history.length === 0) { renderMessage('No games in this range.'); return; }
     const container = $(containerId);
     if (chart) { chart.destroy(); chart = null; }
-    container.classList.remove('loading');
-    if (history.length === 0) {
-      container.innerHTML = '<p class="muted account-elo-chart-empty">No games in this range.</p>';
-      return;
-    }
+    container.classList.remove('tile-loading-spinner');
     container.innerHTML = '';
     try {
       await loadApexCharts();
     } catch (e) {
       // ApexCharts genuinely failed to load (offline, ad-blocker, ...) --
-      // unlike the empty-range case above, there's no chart at all to
-      // show regardless of range, so this hides the whole tile, range
-      // toggle included.
-      hide($(sectionId));
+      // still just a message in the same slot, not a hidden tile.
+      renderMessage("Couldn't load the chart.");
       return;
     }
 
@@ -111,13 +136,14 @@ export function createEloChartController({ containerId, sectionId, rangeToggleId
         type: 'area',
         // A numeric pixel height, not '100%' -- ApexCharts resolves a
         // percentage height against the parent at mount time, and that
-        // measurement came out taller than the container's own 200px
-        // (275px, observed), which the container (no overflow:hidden)
-        // doesn't clip -- the extra height visibly spilled out of the
-        // tile and over whatever sat below it. A concrete number
-        // matching the CSS height in lobby.css always lands exactly
-        // on-target.
-        height: 200,
+        // measurement came out taller than the container's own height
+        // (275px against 200px, observed), which the container (no
+        // overflow:hidden) doesn't clip -- the extra height visibly
+        // spilled out of the tile and over whatever sat below it. A
+        // concrete number matching the CSS height in lobby.css always
+        // lands exactly on-target. Keep this in sync with
+        // .account-elo-chart's own height there.
+        height: 160,
         fontFamily: 'inherit',
         background: 'transparent',
         toolbar: { show: false },
@@ -174,32 +200,45 @@ export function createEloChartController({ containerId, sectionId, rangeToggleId
 
   function onRangeClick(e) {
     const btn = e.target.closest('.account-elo-chart-range-btn');
-    if (!btn) return;
+    if (!btn || btn.disabled) return;
     document.querySelectorAll(`#${rangeToggleId} .account-elo-chart-range-btn`).forEach((b) => {
       b.classList.toggle('selected', b === btn);
     });
     render(filterHistoryByRange(fullHistory, btn.dataset.range));
   }
 
+  // Immediately shows `message` in place of the chart, skipping the
+  // fetch entirely -- for a case the caller already knows synchronously
+  // (a guest profile, before ever asking the server). Disables the
+  // range toggle too, since there's nothing to filter.
+  function showUnavailable(message) {
+    fullHistory = [];
+    setRangeToggleEnabled(false);
+    renderMessage(message);
+  }
+
   // Fetches `historyUrl` (the caller's own /api/profile/<username>/rating_history)
-  // and renders it -- hides the whole section if there's genuinely
-  // nothing to plot (no rated games yet) rather than showing an empty
-  // chart. Callers decide for themselves whether it's worth calling at
-  // all (Account gates on profile.google_id; a Player Profile just
-  // always tries, since bots are real rated participants too now).
+  // and renders it -- a plain message in the same slot (never hiding
+  // anything) if there's genuinely no rated history at all.
+  // `emptyMessage` lets each caller phrase that differently (Account:
+  // "you" phrasing; Player Profile: third person).
   //
   // `isStillRelevant`, if given, is checked right before touching the DOM
   // -- a Player Profile can navigate from one player to another before
   // this resolves (unlike Account, there's no login/logout gate slowing
   // that down), and without this a slow first fetch could paint stale
   // data into a screen that's since moved on to someone else entirely.
-  async function load(historyUrl, isStillRelevant = () => true) {
-    const section = $(sectionId);
+  async function load(historyUrl, { isStillRelevant = () => true, emptyMessage = 'No rated games yet.' } = {}) {
     try {
       const result = await fetchJSON(historyUrl);
       if (!isStillRelevant()) return;
       fullHistory = result.history || [];
-      if (fullHistory.length === 0) { hide(section); return; }
+      if (fullHistory.length === 0) {
+        setRangeToggleEnabled(false);
+        renderMessage(emptyMessage);
+        return;
+      }
+      setRangeToggleEnabled(true);
       // A fresh load (a different profile, or just re-opening this
       // screen) always starts from "All" -- a 7D/30D selection left over
       // from a previous visit silently carrying over would show a
@@ -208,12 +247,11 @@ export function createEloChartController({ containerId, sectionId, rangeToggleId
       document.querySelectorAll(`#${rangeToggleId} .account-elo-chart-range-btn`).forEach((b) => {
         b.classList.toggle('selected', b.dataset.range === 'all');
       });
-      show(section);
       await render(fullHistory);
     } catch (e) {
-      if (isStillRelevant()) hide(section);
+      if (isStillRelevant()) { setRangeToggleEnabled(false); renderMessage("Couldn't load Elo history."); }
     }
   }
 
-  return { load, onRangeClick };
+  return { load, onRangeClick, showUnavailable };
 }

--- a/highsociety/web/templates/_how_to_play_rich.html
+++ b/highsociety/web/templates/_how_to_play_rich.html
@@ -29,6 +29,14 @@
   <p>Spending every last chip can lose you the game outright, no matter how many points you're sitting on.</p>
 </div>
 
+<p>Every player starts with the exact same hand of cash cards — no single lump sum, so a bid is always made up of whichever of these you choose to put forward:</p>
+<div class="rules-money-gallery">
+  {% for value in [1, 2, 3, 4, 6, 8, 10, 12, 15, 20, 25] %}
+  <span class="rules-money-chip">{{ value }}</span>
+  {% endfor %}
+</div>
+<p class="hint">106 in total. Once a card is committed to a bid it's locked in for that auction — you can add more of your remaining cards to raise, but can't swap a committed one back out.</p>
+
 <h3 id="htp2-auctions" class="rules-section-heading">Two kinds of auction</h3>
 
 <div class="rules-auction-compare">
@@ -71,7 +79,7 @@
       <path d="M7 21.9l-4-4 4-4"/><path d="M21 11.9v2a4 4 0 0 1-4 4H3"/>
     </svg>
   </span>
-  <p>In a disgrace auction, passing early is <em>winning</em>. Raising the bid is a trade-off: you risk losing that money for nothing, in exchange for staying out of a card that could become a dealbreaker later on.</p>
+  <p>In a disgrace auction, raising the bid is a trade-off: you risk losing that money, in exchange for staying out of a card that could become a dealbreaker later on.</p>
 </div>
 
 <p class="hint">Money committed to a bid is locked in until the auction resolves — you can raise it later, but can't take it back. Anything you don't win with is returned to you.</p>

--- a/highsociety/web/templates/index.html
+++ b/highsociety/web/templates/index.html
@@ -220,14 +220,20 @@
 
     <!-- ===================== ACCOUNT ===================== -->
     <section id="screen-account" class="screen hidden">
-      <!-- Three separate tiles (profile+stats, Elo chart, Recent Activity)
-           rather than one long panel holding everything -- per explicit
-           feedback that a single giant tile read as an undifferentiated
-           wall, plus a reference mockup showing this same content
-           segregated into its own cards. Each card keeps managing its own
-           visibility independently (chart/activity hide via their own
-           .hidden class, same as before) -- this only changes how they're
-           grouped/spaced when shown, not when each one appears. -->
+      <!-- Two tiles: profile/stats/Elo chart together, Game History
+           separate. Used to be three (stats, chart, and Recent Activity
+           each their own tile) -- collapsed the first two into one,
+           stats and the Elo chart now side by side inside it, per
+           explicit feedback: the chart's own tile popping in after the
+           other two (a slower fetch, plus a real charting library the
+           first time it's ever needed) visibly shoved Game History down
+           and relocated it -- looking like the whole screen was loading
+           "one tile at a time" rather than as one settled layout. Both
+           halves of this row now reserve their space immediately and
+           only ever swap their *internal* content between a loading
+           spinner, real data, or an empty-state message -- never the
+           collapse/reveal that caused the relocation. See
+           ui/eloChart.js's own comment on the same principle. -->
       <div class="account-screen-wrap">
         <div class="card panel account-panel">
           <button type="button" class="screen-back" id="btn-account-back">← Back</button>
@@ -308,100 +314,107 @@
         </div>
         <p id="account-saved" class="account-saved hidden">Saved.</p>
 
-        <!-- Each card's own leading icon is purely decorative (the label
-             below the number already says what it is) -- added because a
-             bare number+label read as noticeably less finished next to
-             every other icon-led element on this app (Home tiles, the
-             Host form's field headers, this very screen's own section
-             headings). Distinct, simple, bold-enough-at-12px glyphs per
-             stat rather than one repeated icon everywhere. -->
-        <div id="account-stats-row" class="account-stats-row account-stats-grid loading">
-          <div class="account-stat">
-            <span class="account-stat-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                <rect x="4" y="4" width="16" height="16" rx="3"/>
-                <circle cx="8.5" cy="8.5" r="1.2" fill="currentColor" stroke="none"/>
-                <circle cx="12" cy="12" r="1.2" fill="currentColor" stroke="none"/>
-                <circle cx="15.5" cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
-              </svg>
-            </span>
-            <span id="account-stat-games" class="account-stat-value">—</span>
-            <span class="account-stat-label">Games played</span>
+        <!-- Stats and the Elo chart side by side (see this tile's own
+             top comment) -- both smaller than their old standalone-tile
+             sizes, since a 3-column stat grid and a full-width chart
+             both read as oversized once they're sharing a row instead of
+             each owning the full tile width. -->
+        <div class="account-stats-chart-row">
+          <!-- Each card's own leading icon is purely decorative (the label
+               below the number already says what it is) -- added because a
+               bare number+label read as noticeably less finished next to
+               every other icon-led element on this app (Home tiles, the
+               Host form's field headers, this very screen's own section
+               headings). Distinct, simple, bold-enough-at-12px glyphs per
+               stat rather than one repeated icon everywhere. -->
+          <div id="account-stats-row" class="account-stats-row account-stats-grid loading">
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="4" y="4" width="16" height="16" rx="3"/>
+                  <circle cx="8.5" cy="8.5" r="1.2" fill="currentColor" stroke="none"/>
+                  <circle cx="12" cy="12" r="1.2" fill="currentColor" stroke="none"/>
+                  <circle cx="15.5" cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
+                </svg>
+              </span>
+              <span id="account-stat-games" class="account-stat-value">—</span>
+              <span class="account-stat-label">Games played</span>
+            </div>
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                  <path d="M12 3.4l2.5 5.4 5.9.6-4.4 4 1.3 5.8L12 16.2l-5.3 3-1.3.9 1.3-5.8-4.4-4 5.9-.6z"/>
+                </svg>
+              </span>
+              <span id="account-stat-wins" class="account-stat-value">—</span>
+              <span class="account-stat-label">Wins</span>
+            </div>
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="8.3"/><circle cx="12" cy="12" r="4.3"/><circle cx="12" cy="12" r="1" fill="currentColor" stroke="none"/>
+                </svg>
+              </span>
+              <span id="account-stat-winrate" class="account-stat-value">—</span>
+              <span class="account-stat-label">Win rate</span>
+            </div>
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="3.5" y="14.5" width="4.5" height="6" rx="1"/><rect x="9.75" y="9.5" width="4.5" height="11" rx="1"/><rect x="16" y="4.5" width="4.5" height="16" rx="1"/>
+                </svg>
+              </span>
+              <span id="account-stat-avg-placement" class="account-stat-value">—</span>
+              <span class="account-stat-label">Avg. placement</span>
+            </div>
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                  <path d="M12 3l7 7-7 11-7-11z"/>
+                </svg>
+              </span>
+              <span id="account-stat-avg-points" class="account-stat-value">—</span>
+              <span class="account-stat-label">Avg. points</span>
+            </div>
+            <div class="account-stat">
+              <span class="account-stat-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <circle cx="12" cy="12" r="8.3"/>
+                  <path d="M12 7.5v9M9.3 9.4c0-1.1 1-2 2.7-2s2.7.9 2.7 1.9c0 2.6-5.4 1.4-5.4 4 0 1.1 1.2 2 2.7 2s2.7-.8 2.7-1.9"/>
+                </svg>
+              </span>
+              <span id="account-stat-avg-money" class="account-stat-value">—</span>
+              <span class="account-stat-label">Avg. money left</span>
+            </div>
           </div>
-          <div class="account-stat">
-            <span class="account-stat-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
-                <path d="M12 3.4l2.5 5.4 5.9.6-4.4 4 1.3 5.8L12 16.2l-5.3 3-1.3.9 1.3-5.8-4.4-4 5.9-.6z"/>
-              </svg>
-            </span>
-            <span id="account-stat-wins" class="account-stat-value">—</span>
-            <span class="account-stat-label">Wins</span>
-          </div>
-          <div class="account-stat">
-            <span class="account-stat-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="12" cy="12" r="8.3"/><circle cx="12" cy="12" r="4.3"/><circle cx="12" cy="12" r="1" fill="currentColor" stroke="none"/>
-              </svg>
-            </span>
-            <span id="account-stat-winrate" class="account-stat-value">—</span>
-            <span class="account-stat-label">Win rate</span>
-          </div>
-          <div class="account-stat">
-            <span class="account-stat-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                <rect x="3.5" y="14.5" width="4.5" height="6" rx="1"/><rect x="9.75" y="9.5" width="4.5" height="11" rx="1"/><rect x="16" y="4.5" width="4.5" height="16" rx="1"/>
-              </svg>
-            </span>
-            <span id="account-stat-avg-placement" class="account-stat-value">—</span>
-            <span class="account-stat-label">Avg. placement</span>
-          </div>
-          <div class="account-stat">
-            <span class="account-stat-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
-                <path d="M12 3l7 7-7 11-7-11z"/>
-              </svg>
-            </span>
-            <span id="account-stat-avg-points" class="account-stat-value">—</span>
-            <span class="account-stat-label">Avg. points</span>
-          </div>
-          <div class="account-stat">
-            <span class="account-stat-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                <circle cx="12" cy="12" r="8.3"/>
-                <path d="M12 7.5v9M9.3 9.4c0-1.1 1-2 2.7-2s2.7.9 2.7 1.9c0 2.6-5.4 1.4-5.4 4 0 1.1 1.2 2 2.7 2s2.7-.8 2.7-1.9"/>
-              </svg>
-            </span>
-            <span id="account-stat-avg-money" class="account-stat-value">—</span>
-            <span class="account-stat-label">Avg. money left</span>
+
+          <!-- Elo history -- ApexCharts (see ui/eloChart.js), the same real
+               plotting library already vendored for this exact purpose.
+               Never hidden as a whole any more (see this tile's own top
+               comment) -- #account-elo-chart always occupies this same
+               slot and only ever swaps its own internal content between a
+               loading spinner, the real chart, or a plain-text reason
+               there's nothing to plot (guest, or zero rated games yet). -->
+          <div class="account-elo-chart-col">
+            <h3>
+              <span class="section-icon" aria-hidden="true">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M3.5 18.5l5.5-6 4 3.5 6.5-8"/><path d="M15.5 7.5h4.5V12"/>
+                </svg>
+              </span>
+              Elo progress
+            </h3>
+            <!-- Purely a client-side filter over history already fetched in
+                 full -- see account.js's onEloChartRangeClick -- switching
+                 ranges never re-fetches. -->
+            <div id="account-elo-chart-range-toggle" class="account-elo-chart-range-toggle">
+              <button type="button" class="account-elo-chart-range-btn" data-range="7">7D</button>
+              <button type="button" class="account-elo-chart-range-btn" data-range="30">30D</button>
+              <button type="button" class="account-elo-chart-range-btn selected" data-range="all">All</button>
+            </div>
+            <div id="account-elo-chart" class="account-elo-chart tile-loading-spinner"></div>
           </div>
         </div>
-
-        </div>
-
-        <!-- Elo history -- ApexCharts (see account.js's loadEloChart), the
-             same real plotting library already vendored for this exact
-             purpose (moved here from the Leaderboard screen, where it was
-             built then asked to be pulled back out and relocated -- this
-             is that relocation). Hidden for a guest (elo never moves) or
-             anyone with no rated games yet -- see loadEloChart's own guard. -->
-        <div id="account-elo-chart-section" class="card panel account-panel hidden">
-          <h3>
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M3.5 18.5l5.5-6 4 3.5 6.5-8"/><path d="M15.5 7.5h4.5V12"/>
-              </svg>
-            </span>
-            Elo progress
-          </h3>
-          <!-- Purely a client-side filter over history already fetched in
-               full -- see account.js's onEloChartRangeClick -- switching
-               ranges never re-fetches. -->
-          <div id="account-elo-chart-range-toggle" class="account-elo-chart-range-toggle">
-            <button type="button" class="account-elo-chart-range-btn" data-range="7">7D</button>
-            <button type="button" class="account-elo-chart-range-btn" data-range="30">30D</button>
-            <button type="button" class="account-elo-chart-range-btn selected" data-range="all">All</button>
-          </div>
-          <div id="account-elo-chart" class="account-elo-chart loading"></div>
         </div>
 
         <!-- Named "Game History" (not "Recent Activity") to match Home's
@@ -420,7 +433,12 @@
              can show comes from that same shared response (see
              get_recent_games' own docstring) and renders identically
              wherever this component appears, not just here. -->
-        <div id="account-recent-activity-section" class="card panel account-panel hidden">
+        <!-- Never hidden as a whole any more (see .account-stats-chart-row's
+             own comment above on the same principle) -- this tile always
+             occupies its slot, showing a loading spinner, real rows, or
+             "no games yet" inside #account-recent-activity-list without
+             ever collapsing/revealing the tile around it. -->
+        <div id="account-recent-activity-section" class="card panel account-panel">
           <div class="home-recent-games-header">
             <h3>
               <span class="section-icon" aria-hidden="true">
@@ -444,7 +462,8 @@
               </button>
             </div>
           </div>
-          <div id="account-recent-activity-list" class="recent-games-list"></div>
+          <div id="account-recent-activity-list" class="recent-games-list tile-loading-spinner"></div>
+          <p id="account-recent-activity-empty" class="muted hidden">No games recorded yet.</p>
         </div>
       </div>
     </section>
@@ -504,93 +523,99 @@
             </span>
           </div>
 
-          <div id="player-profile-stats-row" class="account-stats-row account-stats-grid loading">
-            <div class="account-stat">
-              <span class="account-stat-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                  <rect x="4" y="4" width="16" height="16" rx="3"/>
-                  <circle cx="8.5" cy="8.5" r="1.2" fill="currentColor" stroke="none"/>
-                  <circle cx="12" cy="12" r="1.2" fill="currentColor" stroke="none"/>
-                  <circle cx="15.5" cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
-                </svg>
-              </span>
-              <span id="player-profile-stat-games" class="account-stat-value">—</span>
-              <span class="account-stat-label">Games played</span>
+          <div class="account-stats-chart-row">
+            <div id="player-profile-stats-row" class="account-stats-row account-stats-grid loading">
+              <div class="account-stat">
+                <span class="account-stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="4" y="4" width="16" height="16" rx="3"/>
+                    <circle cx="8.5" cy="8.5" r="1.2" fill="currentColor" stroke="none"/>
+                    <circle cx="12" cy="12" r="1.2" fill="currentColor" stroke="none"/>
+                    <circle cx="15.5" cy="15.5" r="1.2" fill="currentColor" stroke="none"/>
+                  </svg>
+                </span>
+                <span id="player-profile-stat-games" class="account-stat-value">—</span>
+                <span class="account-stat-label">Games played</span>
+              </div>
+              <div class="account-stat">
+                <span class="account-stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                    <path d="M12 3.4l2.5 5.4 5.9.6-4.4 4 1.3 5.8L12 16.2l-5.3 3-1.3.9 1.3-5.8-4.4-4 5.9-.6z"/>
+                  </svg>
+                </span>
+                <span id="player-profile-stat-wins" class="account-stat-value">—</span>
+                <span class="account-stat-label">Wins</span>
+              </div>
+              <div class="account-stat">
+                <span class="account-stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="8.3"/><circle cx="12" cy="12" r="4.3"/><circle cx="12" cy="12" r="1" fill="currentColor" stroke="none"/>
+                  </svg>
+                </span>
+                <span id="player-profile-stat-winrate" class="account-stat-value">—</span>
+                <span class="account-stat-label">Win rate</span>
+              </div>
+              <div class="account-stat">
+                <span class="account-stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                    <rect x="3.5" y="14.5" width="4.5" height="6" rx="1"/><rect x="9.75" y="9.5" width="4.5" height="11" rx="1"/><rect x="16" y="4.5" width="4.5" height="16" rx="1"/>
+                  </svg>
+                </span>
+                <span id="player-profile-stat-avg-placement" class="account-stat-value">—</span>
+                <span class="account-stat-label">Avg. placement</span>
+              </div>
+              <div class="account-stat">
+                <span class="account-stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                    <path d="M12 3l7 7-7 11-7-11z"/>
+                  </svg>
+                </span>
+                <span id="player-profile-stat-avg-points" class="account-stat-value">—</span>
+                <span class="account-stat-label">Avg. points</span>
+              </div>
+              <div class="account-stat">
+                <span class="account-stat-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="8.3"/>
+                    <path d="M12 7.5v9M9.3 9.4c0-1.1 1-2 2.7-2s2.7.9 2.7 1.9c0 2.6-5.4 1.4-5.4 4 0 1.1 1.2 2 2.7 2s2.7-.8 2.7-1.9"/>
+                  </svg>
+                </span>
+                <span id="player-profile-stat-avg-money" class="account-stat-value">—</span>
+                <span class="account-stat-label">Avg. money left</span>
+              </div>
             </div>
-            <div class="account-stat">
-              <span class="account-stat-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
-                  <path d="M12 3.4l2.5 5.4 5.9.6-4.4 4 1.3 5.8L12 16.2l-5.3 3-1.3.9 1.3-5.8-4.4-4 5.9-.6z"/>
-                </svg>
-              </span>
-              <span id="player-profile-stat-wins" class="account-stat-value">—</span>
-              <span class="account-stat-label">Wins</span>
-            </div>
-            <div class="account-stat">
-              <span class="account-stat-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                  <circle cx="12" cy="12" r="8.3"/><circle cx="12" cy="12" r="4.3"/><circle cx="12" cy="12" r="1" fill="currentColor" stroke="none"/>
-                </svg>
-              </span>
-              <span id="player-profile-stat-winrate" class="account-stat-value">—</span>
-              <span class="account-stat-label">Win rate</span>
-            </div>
-            <div class="account-stat">
-              <span class="account-stat-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                  <rect x="3.5" y="14.5" width="4.5" height="6" rx="1"/><rect x="9.75" y="9.5" width="4.5" height="11" rx="1"/><rect x="16" y="4.5" width="4.5" height="16" rx="1"/>
-                </svg>
-              </span>
-              <span id="player-profile-stat-avg-placement" class="account-stat-value">—</span>
-              <span class="account-stat-label">Avg. placement</span>
-            </div>
-            <div class="account-stat">
-              <span class="account-stat-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
-                  <path d="M12 3l7 7-7 11-7-11z"/>
-                </svg>
-              </span>
-              <span id="player-profile-stat-avg-points" class="account-stat-value">—</span>
-              <span class="account-stat-label">Avg. points</span>
-            </div>
-            <div class="account-stat">
-              <span class="account-stat-icon" aria-hidden="true">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                  <circle cx="12" cy="12" r="8.3"/>
-                  <path d="M12 7.5v9M9.3 9.4c0-1.1 1-2 2.7-2s2.7.9 2.7 1.9c0 2.6-5.4 1.4-5.4 4 0 1.1 1.2 2 2.7 2s2.7-.8 2.7-1.9"/>
-                </svg>
-              </span>
-              <span id="player-profile-stat-avg-money" class="account-stat-value">—</span>
-              <span class="account-stat-label">Avg. money left</span>
+
+            <!-- Elo history -- same shared ui/eloChart.js controller
+                 Account's own chart uses. Never hidden as a whole (see
+                 the Account tile's identical comment) -- always occupies
+                 this slot, swapping only its own internal content
+                 between a loading spinner, the real chart, or a plain
+                 reason there's nothing to plot (a bot with no known
+                 difficulty, or zero rated games). Shown for bots too:
+                 they're real rated participants now, and their Elo trend
+                 is genuine, not a placeholder. -->
+            <div class="account-elo-chart-col">
+              <h3>
+                <span class="section-icon" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M3.5 18.5l5.5-6 4 3.5 6.5-8"/><path d="M15.5 7.5h4.5V12"/>
+                  </svg>
+                </span>
+                Elo progress
+              </h3>
+              <div id="player-profile-elo-chart-range-toggle" class="account-elo-chart-range-toggle">
+                <button type="button" class="account-elo-chart-range-btn" data-range="7">7D</button>
+                <button type="button" class="account-elo-chart-range-btn" data-range="30">30D</button>
+                <button type="button" class="account-elo-chart-range-btn selected" data-range="all">All</button>
+              </div>
+              <div id="player-profile-elo-chart" class="account-elo-chart tile-loading-spinner"></div>
             </div>
           </div>
         </div>
 
-        <!-- Elo history -- same shared ui/eloChart.js controller Account's
-             own chart uses (see playerProfile.js), not a second bespoke
-             implementation. Hidden for anyone with no rated games at all
-             (a guest, or a bot with no known difficulty) -- see
-             loadPlayerProfileEloChart's own guard. Shown for bots too:
-             they're real rated participants now, and their Elo trend is
-             genuine, not a placeholder. -->
-        <div id="player-profile-elo-chart-section" class="card panel account-panel hidden">
-          <h3>
-            <span class="section-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M3.5 18.5l5.5-6 4 3.5 6.5-8"/><path d="M15.5 7.5h4.5V12"/>
-              </svg>
-            </span>
-            Elo progress
-          </h3>
-          <div id="player-profile-elo-chart-range-toggle" class="account-elo-chart-range-toggle">
-            <button type="button" class="account-elo-chart-range-btn" data-range="7">7D</button>
-            <button type="button" class="account-elo-chart-range-btn" data-range="30">30D</button>
-            <button type="button" class="account-elo-chart-range-btn selected" data-range="all">All</button>
-          </div>
-          <div id="player-profile-elo-chart" class="account-elo-chart loading"></div>
-        </div>
-
-        <div id="player-profile-history-section" class="card panel account-panel hidden">
+        <!-- Never hidden as a whole any more (see .account-stats-chart-row's
+             own comment above on the same principle). -->
+        <div id="player-profile-history-section" class="card panel account-panel">
           <h3>
             <span class="section-icon" aria-hidden="true">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
@@ -599,7 +624,7 @@
             </span>
             Game History
           </h3>
-          <div id="player-profile-history-list" class="recent-games-list"></div>
+          <div id="player-profile-history-list" class="recent-games-list tile-loading-spinner"></div>
           <p id="player-profile-history-empty" class="muted hidden">No games recorded yet.</p>
           <div id="player-profile-history-pagination" class="leaderboard-pagination hidden">
             <button type="button" id="btn-player-profile-history-prev" class="secondary" disabled>← Prev</button>

--- a/tests/common/test_elo.py
+++ b/tests/common/test_elo.py
@@ -2,44 +2,44 @@ from highsociety.code.common.elo import DEFAULT_K_FACTOR, compute_elo_deltas
 
 
 def test_fewer_than_two_players_yields_no_change():
-    assert compute_elo_deltas([{"username": "alice", "points": 10, "rating": 1000}]) == {"alice": 0}
+    assert compute_elo_deltas([{"username": "alice", "placement": 1, "rating": 1000}]) == {"alice": 0}
     assert compute_elo_deltas([]) == {}
 
 
 def test_equal_ratings_two_player_win_loss_is_half_k():
     deltas = compute_elo_deltas([
-        {"username": "alice", "points": 10, "rating": 1000},
-        {"username": "bob", "points": 5, "rating": 1000},
+        {"username": "alice", "placement": 1, "rating": 1000},
+        {"username": "bob", "placement": 2, "rating": 1000},
     ])
     assert deltas == {"alice": DEFAULT_K_FACTOR // 2, "bob": -DEFAULT_K_FACTOR // 2}
 
 
-def test_tied_points_is_a_draw_no_change_at_equal_rating():
+def test_tied_placement_is_a_draw_no_change_at_equal_rating():
     deltas = compute_elo_deltas([
-        {"username": "alice", "points": 7, "rating": 1000},
-        {"username": "bob", "points": 7, "rating": 1000},
+        {"username": "alice", "placement": 1, "rating": 1000},
+        {"username": "bob", "placement": 1, "rating": 1000},
     ])
     assert deltas == {"alice": 0, "bob": 0}
 
 
 def test_upset_win_gains_more_than_an_expected_win():
     underdog_deltas = compute_elo_deltas([
-        {"username": "underdog", "points": 10, "rating": 800},
-        {"username": "favorite", "points": 5, "rating": 1200},
+        {"username": "underdog", "placement": 1, "rating": 800},
+        {"username": "favorite", "placement": 2, "rating": 1200},
     ])
     favorite_deltas = compute_elo_deltas([
-        {"username": "favorite", "points": 10, "rating": 1200},
-        {"username": "underdog", "points": 5, "rating": 800},
+        {"username": "favorite", "placement": 1, "rating": 1200},
+        {"username": "underdog", "placement": 2, "rating": 800},
     ])
     assert underdog_deltas["underdog"] > favorite_deltas["favorite"] > 0
 
 
 def test_deltas_sum_to_roughly_zero_for_a_multiplayer_game():
     deltas = compute_elo_deltas([
-        {"username": "alice", "points": 15, "rating": 1000},
-        {"username": "bob", "points": 10, "rating": 1000},
-        {"username": "carol", "points": 5, "rating": 1000},
-        {"username": "dave", "points": 0, "rating": 1000},
+        {"username": "alice", "placement": 1, "rating": 1000},
+        {"username": "bob", "placement": 2, "rating": 1000},
+        {"username": "carol", "placement": 3, "rating": 1000},
+        {"username": "dave", "placement": 4, "rating": 1000},
     ])
     # Individually rounded, so not exactly zero, but close.
     assert abs(sum(deltas.values())) <= 2
@@ -48,9 +48,31 @@ def test_deltas_sum_to_roughly_zero_for_a_multiplayer_game():
 
 def test_winner_gains_and_loser_loses_regardless_of_table_size():
     deltas = compute_elo_deltas([
-        {"username": "alice", "points": 20, "rating": 1000},
-        {"username": "bob", "points": 10, "rating": 1000},
-        {"username": "carol", "points": 0, "rating": 1000},
+        {"username": "alice", "placement": 1, "rating": 1000},
+        {"username": "bob", "placement": 2, "rating": 1000},
+        {"username": "carol", "placement": 3, "rating": 1000},
     ])
     assert deltas["alice"] > 0
     assert deltas["carol"] < 0
+
+
+def test_placement_not_points_decides_the_pairwise_outcome():
+    """Real bug, confirmed live in production: a player eliminated for
+    having the least money can still have the game's highest raw score
+    (the win condition explicitly ranks eliminated players last
+    regardless of points -- see game_history.py's _placement_tier), but
+    compute_elo_deltas used to compare raw points directly, so that
+    player's Elo still went *up* despite finishing dead last. Passing
+    the already-elimination-aware placement instead must rank them
+    correctly regardless of how many points they scored."""
+    deltas = compute_elo_deltas([
+        # Finished 5th (eliminated) despite the highest points of the table.
+        {"username": "eliminated_leader", "placement": 5, "rating": 1000},
+        {"username": "actual_winner", "placement": 1, "rating": 1000},
+        {"username": "second", "placement": 2, "rating": 1000},
+        {"username": "third", "placement": 3, "rating": 1000},
+        {"username": "fourth", "placement": 4, "rating": 1000},
+    ])
+    assert deltas["eliminated_leader"] < 0
+    assert deltas["actual_winner"] > 0
+    assert deltas["eliminated_leader"] < deltas["fourth"]

--- a/tests/common/test_game_history.py
+++ b/tests/common/test_game_history.py
@@ -403,8 +403,8 @@ def test_record_finished_game_averages_elo_deltas_for_same_difficulty_bot_seats(
     cursor.fetchone.side_effect = iter([
         (1,),                    # INSERT INTO games ... RETURNING id
         (10, "g-alice", 1000),   # _upsert_player(alice)
-        (55, 1000),               # bots lookup for medium bot A
-        (55, 1000),               # bots lookup for medium bot B -- same shared player_id
+        (55, 900),                # bots lookup for medium bot A -- deliberately not 1000 (see below)
+        (55, 900),                # bots lookup for medium bot B -- same shared player_id
     ])
     participants = [
         {"is_bot": False, "username": "alice", "name": "Alice", "game_username": "alice",
@@ -423,11 +423,22 @@ def test_record_finished_game_averages_elo_deltas_for_same_difficulty_bot_seats(
         )
 
     # Ground truth: what each seat's delta would independently be, exactly
-    # matching the rated_standings this call built internally.
+    # matching the rated_standings this call built internally -- by
+    # placement (medium bot a won outright = 1st, alice 2nd, medium bot b
+    # eliminated so ranks last regardless of its own points), not raw
+    # points (see elo.compute_elo_deltas' own docstring on why those
+    # can disagree). Bots deliberately rated below alice (900 vs 1000),
+    # not the same 1000 for everyone -- at equal ratings, one bot seat
+    # winning and the other losing produces exactly offsetting +/-16
+    # deltas that average to a coincidental *zero* combined change, which
+    # would make this test unable to tell "averaged correctly" apart
+    # from "silently skipped" (record_finished_game only writes a
+    # ratings row/elo update when the combined delta is actually
+    # non-zero).
     expected_seat_deltas = elo.compute_elo_deltas([
-        {"username": "alice", "points": 8, "rating": 1000},
-        {"username": "medium bot a", "points": 40, "rating": 1000},
-        {"username": "medium bot b", "points": 18, "rating": 1000},
+        {"username": "alice", "placement": 2, "rating": 1000},
+        {"username": "medium bot a", "placement": 1, "rating": 900},
+        {"username": "medium bot b", "placement": 3, "rating": 900},
     ])
     expected_bot_delta = round(
         (expected_seat_deltas["medium bot a"] + expected_seat_deltas["medium bot b"]) / 2


### PR DESCRIPTION
## Summary
Implements BACKEND_REWORK.MD + FRONTEND_REWORK.MD in full:

- **Real production bug fix**: Elo deltas were computed from raw points instead of final placement, so a points-leader who got eliminated (the game's own money-elimination win condition) could gain Elo despite losing. `compute_elo_deltas` now takes `placement` (already elimination-aware) instead of `points`.
- Account/Player Profile screens reworked: stats + Elo chart now sit side by side in one tile, Game History in a second — both always visible at their final size, with an internal spinner while loading, so nothing pops in one tile at a time or relocates once data arrives (the exact bug reported: "I can see game history first and then graphs getting relocated").
- Fixed the Play/Join/Host/Leaderboard/How to Play/Account tiles starting at inconsistent vertical alignment (root cause: `#home-grid` never actually left the layout when a sub-panel showed).
- How to Play made visual and interactive: real card art, an auction-type comparison, cue-card callouts, a scripted demo, and a money-card gallery.
- New "never hide a loading tile, reserve its layout and show a spinner inside it" principle written into CLAUDE.md.

## Testing
Full backend suite passing; extensive live Playwright verification of the Account/Player Profile loading behavior and the alignment fix across all screens (see commit messages for detail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)